### PR TITLE
Always pull latest worker image

### DIFF
--- a/src/api/general-services/work-submit.js
+++ b/src/api/general-services/work-submit.js
@@ -122,6 +122,7 @@ class WorkSubmitService {
                 {
                   name: `job-${this.workerHash}-container`,
                   image: imageUrl,
+                  imagePullPolicy: 'Always',
                   env: [
                     {
                       name: 'WORK_QUEUE',


### PR DESCRIPTION
This fixes a bug I created accidentally: the tag of the image was changed from `latest` to `refs-heads-master-latest`, which changes the default pull policy from `Always` to `IfNotPresent`. See [here](https://kubernetes.io/docs/concepts/containers/images/).

This fixes this issue and makes sure we always get the latest worker image.