### PR TITLE
add expressionType to GeneExpression API Schema

### DIFF
--- a/src/specs/api.yaml
+++ b/src/specs/api.yaml
@@ -565,6 +565,7 @@ components:
         expressionType:
           type: string
           description: The type of the gene expression value
+          default : 'raw'
       required:
         - cells
         - data

--- a/src/specs/api.yaml
+++ b/src/specs/api.yaml
@@ -562,6 +562,9 @@ components:
         maxExpression:
           type: number
           description: The maximum expression value of that gene
+        expressionType:
+          type: string
+          description: The type of the gene expression value
       required:
         - cells
         - data
@@ -584,6 +587,10 @@ components:
           type: boolean
           description: Whether to perform feature scaling (normalization to unit variance and zero mean). Defaults to `false` if not specified.
           default: 'false'
+        expressionType:
+          type: string
+          description: Type of gene expression value that is requested. Defaults to `raw` if not specified.
+          default: 'raw'
       required:
         - name
         - genes


### PR DESCRIPTION
# Background

Currently, the API schema for the GeneExpression task does not take “expression type“ as an argument. Change to the API Schema is needed to support GeneExpression type

#### Link to issue 

https://biomage.atlassian.net/browse/BIOMAGE-430

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

Add `expressionType` into WorkSchema (defaults to `raw`) and WorkResponse in `api.yaml`. Both are optional to not break the current API.

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [X] Tested locally with Inframock
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
