### PR TITLE
In WorkSchemaGetEmbedding, replace 'type' property with 'config'

### DIFF
--- a/src/specs/api.yaml
+++ b/src/specs/api.yaml
@@ -458,16 +458,12 @@ components:
           type: string
           example: GetEmbedding
           description: The name of this work -- must be `GetEmbedding`.
-        type:
-          type: string
-          enum:
-            - pca
-            - tsne
-            - umap
-          description: The type of embedding to compute.
+        config:
+          type: object
+          description: The configuration settings to use for this embedding. This will be used both to configure the embedding and to cache the results.
       required:
         - name
-        - type
+        - config
     WorkSchemaListGenes:
       title: WorkSchemaListGenes
       type: object

--- a/src/specs/api.yaml
+++ b/src/specs/api.yaml
@@ -460,7 +460,7 @@ components:
           description: The name of this work -- must be `GetEmbedding`.
         config:
           type: object
-          description: The configuration settings to use for this embedding. This will be used both to configure the embedding and to cache the results.
+          description: The configuration settings to use for calculation of this embedding.
       required:
         - name
     WorkSchemaListGenes:

--- a/src/specs/api.yaml
+++ b/src/specs/api.yaml
@@ -463,7 +463,6 @@ components:
           description: The configuration settings to use for this embedding. This will be used both to configure the embedding and to cache the results.
       required:
         - name
-        - config
     WorkSchemaListGenes:
       title: WorkSchemaListGenes
       type: object

--- a/src/specs/api.yaml
+++ b/src/specs/api.yaml
@@ -463,6 +463,15 @@ components:
           description: The configuration settings to use for calculation of this embedding.
       required:
         - name
+    WorkResponseGetEmbedding:
+      type: array
+      description: 'The response schema for the `GetEmbedding` task.'
+      items:
+        type: array
+        items:
+          type: number
+          minItems: 2
+          maxItems: 2
     WorkSchemaListGenes:
       title: WorkSchemaListGenes
       type: object

--- a/src/specs/api.yaml
+++ b/src/specs/api.yaml
@@ -467,7 +467,8 @@ components:
             - pca
             - tsne
             - umap
-          description: The type of embedding to compute (deprecated; use config).
+          description: The type of embedding to compute.
+          deprecated: true
       required:
         - name
     WorkResponseGetEmbedding:

--- a/src/specs/api.yaml
+++ b/src/specs/api.yaml
@@ -461,6 +461,13 @@ components:
         config:
           type: object
           description: The configuration settings to use for calculation of this embedding.
+        type:
+          type: string
+          enum:
+            - pca
+            - tsne
+            - umap
+          description: The type of embedding to compute (deprecated; use config).
       required:
         - name
     WorkResponseGetEmbedding:

--- a/src/specs/api.yaml
+++ b/src/specs/api.yaml
@@ -457,6 +457,7 @@ components:
         name:
           type: string
           example: GetEmbedding
+          pattern: GetEmbedding
           description: The name of this work -- must be `GetEmbedding`.
         config:
           type: object

--- a/tests/api/event-services/work-request.test.js
+++ b/tests/api/event-services/work-request.test.js
@@ -29,7 +29,7 @@ describe('handleWorkRequest', () => {
       socketId: '6789',
       experimentId: 'my-experiment',
       timeout: '2001-01-01T00:00:00Z',
-      body: { name: 'GetEmbedding', type: 'tsne' },
+      body: { name: 'GetEmbedding', config: {} },
     };
 
     try {

--- a/tests/api/general-services/work-submit.test.js
+++ b/tests/api/general-services/work-submit.test.js
@@ -11,7 +11,7 @@ describe('tests for the work-submit service', () => {
       socketId: '6789',
       experimentId: 'my-experiment',
       timeout: '2099-01-01T00:00:00Z',
-      body: { name: 'GetEmbedding', type: 'pca' },
+      body: { name: 'GetEmbedding', config: { type: 'pca' } },
     };
 
     AWSMock.setSDKInstance(AWS);

--- a/tests/api/route-services/work-response.test.js
+++ b/tests/api/route-services/work-response.test.js
@@ -24,7 +24,9 @@ describe('tests for the work-response service', () => {
       timeout: '2099-01-01T00:00:00Z',
       body: {
         name: 'GetEmbedding',
-        type: 'pca',
+        config: {
+            type: 'pca',
+        },
       },
     },
     response: {


### PR DESCRIPTION
In WorkSchemaGetEmbedding, replace 'type' property with 'config', an abitrary object.

# Background
#### Link to issue 
https://biomage.atlassian.net/browse/BIOMAGE-445

#### Link to staging deployment URL 

https://ui-biomage-445.scp-staging.biomage.net/

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

I'm not sure this is done but I wanted to make sure I haven't misunderstood the task. This would allow any object as defined by convention between the UI and worker as long as it has a name and 'config' member, which would contain the type, UI settings and so on. As mentioned in the ticket, making this any more rigidly defined would slow down faster iteration of both components.

# Changes
### Code changes

* Swagger yaml spec updated

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock
- [x] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [x] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
