### PR TITLE
Disable caching in staging

### DIFF
--- a/src/cache/generate-config.js
+++ b/src/cache/generate-config.js
@@ -10,6 +10,7 @@ const BASE_CONFIG = {
   redisGetTimeout: 3000,
   // ttl has to be in ms. Set to 36 hours = 36*60*60*1000 ms = 129600000
   l1CacheSettings: { ttl: 129600000, size: 1000, minLatencyToStore: 50 },
+  enabled: config.cachingEnabled,
 };
 
 const updateRedisEndpoints = async () => {

--- a/src/config/default-config.js
+++ b/src/config/default-config.js
@@ -59,16 +59,19 @@ const config = {
     prefix: '/',
   },
   workerInstanceConfigUrl: 'https://raw.githubusercontent.com/biomage-ltd/iac/master/releases/production/worker.yaml',
+  cachingEnabled: true,
 };
 
 if (config.clusterEnv === 'staging') {
   config.workerInstanceConfigUrl = `https://raw.githubusercontent.com/biomage-ltd/iac/master/releases/staging/${config.sandboxId}.yaml`;
+  config.cachingEnabled = false;
 }
 
 // We are in the `development` clusterEnv, meaning we run on
 // InfraMock. Set up API accordingly.
 if (config.clusterEnv === 'development') {
   logger.log('We are running on a development cluster, patching AWS to use InfraMock endpoint...');
+  config.cachingEnabled = false;
   config.awsAccountIdPromise = async () => '000000000000';
   AWS.config.update({
     endpoint: 'http://localhost:4566',

--- a/src/config/test-config.js
+++ b/src/config/test-config.js
@@ -15,4 +15,5 @@ module.exports = {
   api: {
     prefix: '/',
   },
+  cachingEnabled: false,
 };

--- a/tests/cache/disabled-cache.test.js
+++ b/tests/cache/disabled-cache.test.js
@@ -1,0 +1,72 @@
+// const Redis = require('ioredis-mock');
+const _ = require('lodash');
+const CacheSingleton = require('../../src/cache');
+const { BASE_CONFIG } = require('../../src/cache/generate-config');
+const { cacheGetRequest, cacheSetResponse } = require('../../src/utils/cache-request');
+
+jest.mock('ioredis', () => {
+  // eslint-disable-next-line global-require
+  const Redis = require('ioredis-mock');
+
+  if (typeof Redis === 'object') {
+    // the first mock is an ioredis shim because ioredis-mock depends on it
+    // https://github.com/stipsan/ioredis-mock/blob/master/src/index.js#L101-L111
+    return {
+      Command: { _transformer: { argument: {}, reply: {} } },
+    };
+  }
+
+  // second mock is the actual constructor. note that this must be
+  // a `function` and NOT an anonymous function, as the latter is not a valid
+  // ES constructor
+
+  // eslint-disable-next-line func-names
+  return function (args) {
+    const object = new Redis({ ...args, lazyConnect: false });
+    object.status = 'ready';
+
+    return object;
+  };
+});
+
+describe('disabled caching works', () => {
+  const mockResponse = {
+    request: {},
+    result: ['some result'],
+  };
+
+  it('creates a new instance with caching disabled', () => {
+    // Minimum latency is set to 0 to get consistent effects. This will ensure
+    // we always get a high enough latency to use the L1 cache.
+    CacheSingleton.get({
+      ...BASE_CONFIG,
+      l1CacheSettings: {
+        ...BASE_CONFIG.l1CacheSettings,
+        minLatencyToStore: 0,
+      },
+      enabled: false,
+    });
+  });
+
+  it('creates a reader and a primary endpoint', () => {
+    const cache = CacheSingleton.get();
+
+    const primary = cache.getClientAndStatus('primary');
+    const reader = cache.getClientAndStatus('reader');
+
+    expect(primary.ready).toEqual(true);
+    expect(reader.ready).toEqual(true);
+
+    expect(reader).not.toEqual(primary);
+  });
+
+  it('can set data', async () => {
+    const cache = CacheSingleton.get();
+    await cache.set('keya', mockResponse);
+  });
+
+  it('set data is discarded', async () => {
+    const cache = CacheSingleton.get();
+    await expect(cache.get('keya')).rejects.toThrow();
+  });
+});

--- a/tests/cache/index-l1-hot.test.js
+++ b/tests/cache/index-l1-hot.test.js
@@ -44,6 +44,7 @@ describe('cache, always saves to L1', () => {
         ...BASE_CONFIG.l1CacheSettings,
         minLatencyToStore: 0,
       },
+      enabled: true,
     });
   });
 


### PR DESCRIPTION
# Background
#### Link to issue
https://biomage.atlassian.net/browse/BIOMAGE-547

#### Link to staging deployment URL
https://ui-xz6m317f79g8iwgfwy5idnj3sc.scp-staging.biomage.net/

#### Links to any Pull Requests related to this
N/A

#### Anything else the reviewers should know about the changes here
The feature is written in such a way as to be as unintrusive as possible. Therefore, when caching is disabled, code related to caching (including connecting to the cluster) will still run, except no gets or sets will actually go through to the caches. This is to ensure no breaking changes happen to the core of the caching component (e.g. connections, timeouts, etc.) that are only caught in production.

# Changes
### Code changes
Disabled caching in development and staging

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [x] Unit tests written
- [x] Tested locally with Inframock
- [x] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [x] Relevant Github READMEs updated
- [x] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [x] Photo of a cute animal attached to this PR
![image](https://user-images.githubusercontent.com/16019444/107051561-8060a380-67c4-11eb-8b33-e05569528731.png)
