### PR TITLE
API to send proper 404 error when an experiment is not found

### DIFF
--- a/src/api/route-services/experiment.js
+++ b/src/api/route-services/experiment.js
@@ -5,6 +5,7 @@ const {
   createDynamoDbInstance, convertToJsObject, convertToDynamoDbRecord, configArrayToUpdateObjs,
 } = require('../../utils/dynamoDb');
 
+const NotFoundError = require('../../utils/NotFoundError');
 
 class ExperimentService {
   constructor() {
@@ -24,7 +25,12 @@ class ExperimentService {
       Key: key,
       ProjectionExpression: 'experimentId, experimentName',
     };
+
     const data = await dynamodb.getItem(params).promise();
+
+    if (Object.keys(data).length === 0) {
+      throw new NotFoundError('Experiment does not exist.');
+    }
 
     const prettyData = convertToJsObject(data.Item);
     return prettyData;
@@ -42,6 +48,11 @@ class ExperimentService {
     };
 
     const data = await dynamodb.getItem(params).promise();
+
+    if (Object.keys(data).length === 0) {
+      throw new NotFoundError('Experiment does not exist.');
+    }
+
     const prettyData = convertToJsObject(data.Item);
 
     return prettyData;
@@ -54,8 +65,6 @@ class ExperimentService {
     key = convertToDynamoDbRecord(key);
 
     const data = convertToDynamoDbRecord({ ':x': cellSetData });
-
-    logger.log(data);
 
     const params = {
       TableName: this.tableName,
@@ -81,6 +90,11 @@ class ExperimentService {
     };
 
     const data = await dynamodb.getItem(params).promise();
+
+    if (Object.keys(data).length === 0) {
+      throw new NotFoundError('Experiment does not exist.');
+    }
+
     const prettyData = convertToJsObject(data.Item);
 
     return prettyData;

--- a/src/api/route-services/experiment.js
+++ b/src/api/route-services/experiment.js
@@ -1,6 +1,5 @@
 const config = require('../../config');
 const mockData = require('./mock-data.json');
-const logger = require('../../utils/logging');
 const {
   createDynamoDbInstance, convertToJsObject, convertToDynamoDbRecord, configArrayToUpdateObjs,
 } = require('../../utils/dynamoDb');

--- a/src/loaders/express.js
+++ b/src/loaders/express.js
@@ -31,6 +31,8 @@ module.exports = async (app) => {
   // Custom error handler.
   // eslint-disable-next-line no-unused-vars
   app.use((err, req, res, next) => {
+    console.log(err.status);
+
     // format errors
     res.status(err.status || 500).json({
       message: err.message,

--- a/src/loaders/express.js
+++ b/src/loaders/express.js
@@ -4,6 +4,7 @@ const path = require('path');
 const OpenApiValidator = require('express-openapi-validator');
 const http = require('http');
 const io = require('socket.io');
+const logger = require('../utils/logging');
 
 module.exports = async (app) => {
   // Useful if you're behind a reverse proxy (Heroku, Bluemix, AWS ELB, Nginx, etc)
@@ -31,7 +32,8 @@ module.exports = async (app) => {
   // Custom error handler.
   // eslint-disable-next-line no-unused-vars
   app.use((err, req, res, next) => {
-    console.log(err.status);
+    logger.log('Error thrown in HTTP request');
+    logger.log(err);
 
     // format errors
     res.status(err.status || 500).json({

--- a/src/specs/api.yaml
+++ b/src/specs/api.yaml
@@ -27,7 +27,7 @@ paths:
         - heartbeat
       summary: API health check
       operationId: checkHealth
-      x-eov-operation-id: health#check
+      x-eov-operation-id: 'health#check'
       x-eov-operation-handler: routes/health
       responses:
         '200':
@@ -58,7 +58,7 @@ paths:
   /workResults:
     post:
       operationId: receiveWork
-      x-eov-operation-id: work#response
+      x-eov-operation-id: 'work#response'
       x-eov-operation-handler: routes/work
       requestBody:
         description: The data sent by AWS SNS.
@@ -105,7 +105,7 @@ paths:
       summary: Look up experiment by ID
       description: Returns the main details of the experiment.
       operationId: getExperimentById
-      x-eov-operation-id: experiment#findByID
+      x-eov-operation-id: 'experiment#findByID'
       x-eov-operation-handler: routes/experiment
       responses:
         '200':
@@ -114,10 +114,16 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Experiment'
-        '400':
-          description: Invalid ID supplied
         '404':
           description: Experiment not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties: {}
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/ApiError'
     parameters:
       - schema:
           type: string
@@ -132,7 +138,7 @@ paths:
       summary: Retrieve cell sets
       description: Returns a hirearchical view of cell sets in the experiment.
       operationId: getExperimentCellSetsById
-      x-eov-operation-id: experiment#getCellSets
+      x-eov-operation-id: 'experiment#getCellSets'
       x-eov-operation-handler: routes/experiment
       responses:
         '200':
@@ -148,6 +154,10 @@ paths:
                       $ref: '#/components/schemas/CellSets'
         '404':
           description: Experiment not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
     parameters:
       - name: experimentId
         in: path
@@ -158,7 +168,7 @@ paths:
     put:
       summary: ''
       operationId: updateExperimentCellSetsById
-      x-eov-operation-id: experiment#updateCellSets
+      x-eov-operation-id: 'experiment#updateCellSets'
       x-eov-operation-handler: routes/experiment
       responses:
         '200':
@@ -186,7 +196,7 @@ paths:
       summary: Retrieve processing configuration
       description: Returns a hirearchical of processing configuration used in the experiment.
       operationId: getExperimentProcessingConfigById
-      x-eov-operation-id: experiment#getProcessingConfig
+      x-eov-operation-id: 'experiment#getProcessingConfig'
       x-eov-operation-handler: routes/experiment
       responses:
         '200':
@@ -217,6 +227,10 @@ paths:
                         $ref: '#/components/schemas/ProcessingConfigConfigureEmbedding'
         '404':
           description: Experiment not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
       tags:
         - processing-config
     parameters:
@@ -229,7 +243,7 @@ paths:
     put:
       summary: ''
       operationId: updateExperimentProcessingConfigById
-      x-eov-operation-id: experiment#updateProcessingConfig
+      x-eov-operation-id: 'experiment#updateProcessingConfig'
       x-eov-operation-handler: routes/experiment
       responses:
         '200':
@@ -277,7 +291,7 @@ paths:
     put:
       summary: ''
       operationId: updatePlotTable
-      x-eov-operation-id: plots-tables#update
+      x-eov-operation-id: 'plots-tables#update'
       x-eov-operation-handler: routes/plots-tables
       responses:
         '200':
@@ -304,7 +318,7 @@ paths:
     get:
       summary: ''
       operationId: getPlotTable
-      x-eov-operation-id: plots-tables#read
+      x-eov-operation-id: 'plots-tables#read'
       x-eov-operation-handler: routes/plots-tables
       responses:
         '200':
@@ -317,7 +331,7 @@ paths:
     delete:
       summary: ''
       operationId: deletePlotTable
-      x-eov-operation-id: plots-tables#delete
+      x-eov-operation-id: 'plots-tables#delete'
       x-eov-operation-handler: routes/plots-tables
       responses:
         '200':
@@ -417,7 +431,7 @@ components:
               description: Whether the result should be cached.
             error:
               type: boolean
-              description: Whether there's been an error.
+              description: "Whether there's been an error."
       required:
         - results
         - response
@@ -561,7 +575,7 @@ components:
         - name
     WorkResponseGetEmbedding:
       type: array
-      description: 'The response schema for the `GetEmbedding` task.'
+      description: The response schema for the `GetEmbedding` task.
       items:
         type: array
         items:
@@ -588,7 +602,7 @@ components:
           description: What field to order the results by.
         orderDirection:
           type: string
-          pattern: ^(asc)|(desc)|(ASC)|(DESC)$
+          pattern: '^(asc)|(desc)|(ASC)|(DESC)$'
           description: 'The direction of the ordering (ASC, DESC)'
         offset:
           type: integer

--- a/src/utils/NotFoundError.js
+++ b/src/utils/NotFoundError.js
@@ -1,0 +1,8 @@
+class NotFoundError extends Error {
+  constructor(message) {
+    super(message);
+    this.status = 404;
+  }
+}
+
+module.exports = NotFoundError;


### PR DESCRIPTION
# Background
#### Link to issue
https://biomage.atlassian.net/browse/BIOMAGE-483

#### Link to staging deployment URL 
TBD

#### Links to any Pull Requests related to this
N/A

#### Anything else the reviewers should know about the changes here
N/A

# Changes
### Code changes
This fixes a bug where invalid experiment IDs would result in a 500 error instead of a 404. This made it difficult to debug issues with non-existing experiment IDs and is bad UX. This fixes the problem.

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [x] Unit tests written
- [x] Tested locally with Inframock
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [x] Relevant Github READMEs updated
- [x] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
