### PR TITLE
Upload qc plotdata

### DIFF
--- a/src/api/general-services/pipeline-manage/index.js
+++ b/src/api/general-services/pipeline-manage/index.js
@@ -115,15 +115,17 @@ const createPipeline = async (experimentId, processingConfigUpdates) => {
   const processingRes = await experimentService.getProcessingConfig(experimentId);
   const { processingConfig } = processingRes;
 
-  processingConfigUpdates.forEach(({ name, body }) => {
-    if (!processingConfig[name]) {
-      processingConfig[name] = body;
+  if (processingConfigUpdates) {
+    processingConfigUpdates.forEach(({ name, body }) => {
+      if (!processingConfig[name]) {
+        processingConfig[name] = body;
 
-      return;
-    }
+        return;
+      }
 
-    _.merge(processingConfig[name], body);
-  });
+      _.merge(processingConfig[name], body);
+    });
+  }
 
   const context = {
     experimentId,

--- a/src/api/route-services/pipeline-response.js
+++ b/src/api/route-services/pipeline-response.js
@@ -77,8 +77,7 @@ const pipelineResponse = async (io, message) => {
 
     Promise.all(plotConfigUploads);
   }
-  
-  const { taskName } = message.input;
+
   experimentService.updateProcessingConfig(experimentId, [{ name: taskName, body: output.config }]);
 
   // Concatenate into a proper response.

--- a/src/api/route-services/pipeline-response.js
+++ b/src/api/route-services/pipeline-response.js
@@ -2,6 +2,8 @@ const AWS = require('../../utils/requireAWS');
 const validateRequest = require('../../utils/schema-validator');
 const logger = require('../../utils/logging');
 
+const PlotsTablesService = require('./plots-tables');
+
 const pipelineResponse = async (io, message) => {
   await validateRequest(message, 'PipelineResponse.v1.yaml');
 
@@ -26,6 +28,17 @@ const pipelineResponse = async (io, message) => {
 
   if (output.config) {
     await validateRequest(output.config, 'ProcessingConfigBodies.v1.yaml');
+  }
+
+  if (output.plotData) {
+    await PlotsTablesService.create(
+      experimentId,
+      'default',
+      {
+        locationId: `DataProcessing-${output.task_name}`,
+        plotData: output.plotData,
+      },
+    );
   }
 
   // Concatenate into a proper response.

--- a/src/api/route-services/pipeline-response.js
+++ b/src/api/route-services/pipeline-response.js
@@ -75,7 +75,12 @@ const pipelineResponse = async (io, message) => {
       )
     ));
 
-    Promise.all(plotConfigUploads);
+    logger.log('Uploading plotData for', taskName, 'to DynamoDB');
+
+    // Promise.all stops if it encounters errors.
+    // This handles errors so that error in one upload does not stop others
+    // Resulting promise resolves to an array with the resolve/reject value of p
+    Promise.all(plotConfigUploads.map((p) => p.catch((e) => e)));
   }
 
   experimentService.updateProcessingConfig(experimentId, [{ name: taskName, body: output.config }]);

--- a/src/api/route-services/plots-tables.js
+++ b/src/api/route-services/plots-tables.js
@@ -1,6 +1,5 @@
 const config = require('../../config');
 const { createDynamoDbInstance, convertToJsObject, convertToDynamoDbRecord } = require('../../utils/dynamoDb');
-const logger = require('../../utils/logging');
 
 class PlotsTablesService {
   constructor() {
@@ -30,8 +29,6 @@ class PlotsTablesService {
 
   async updatePlotData(experimentId, plotUuid, plotData) {
     const marshalledData = convertToDynamoDbRecord({ ':d': plotData });
-
-    logger.log('debugging marshalled data', marshalledData);
 
     const params = {
       TableName: this.tableName,

--- a/src/api/route-services/plots-tables.js
+++ b/src/api/route-services/plots-tables.js
@@ -28,14 +28,18 @@ class PlotsTablesService {
   }
 
   async updatePlotData(experimentId, plotUuid, plotData) {
-    const marshalledData = convertToDynamoDbRecord({ ':d': plotData });
+    const marshalledData = convertToDynamoDbRecord({
+      ':plotData': plotData,
+      ':plotType': plotUuid,
+      ':config': {},
+    });
 
     const params = {
       TableName: this.tableName,
       Key: {
         experimentId: { S: experimentId }, plotUuid: { S: plotUuid },
       },
-      UpdateExpression: 'SET plotData = :d',
+      UpdateExpression: 'SET plotData = :plotData, plotType = if_not_exists(plotType, :plotType), config = if_not_exists(config, :config)',
       ExpressionAttributeValues: marshalledData,
       ReturnValues: 'UPDATED_NEW',
     };

--- a/src/api/routes/plots-tables.js
+++ b/src/api/routes/plots-tables.js
@@ -34,7 +34,7 @@ module.exports = {
   'plots-tables#delete': (req, res, next) => {
     const { experimentId, plotUuid } = req.params;
 
-    plotsTablesService.dekete(experimentId, plotUuid)
+    plotsTablesService.delete(experimentId, plotUuid)
       .then((response) => res.json(response))
       .catch(next);
   },

--- a/src/specs/models/api-body-schemas/PlotTableConfig.v1.yaml
+++ b/src/specs/models/api-body-schemas/PlotTableConfig.v1.yaml
@@ -11,6 +11,27 @@ properties:
   plotType:
     type: string
     description: The type of the plot to be saved. Can be one of the values specified herein.
+    enum:
+      - umisInCells
+      - umisCellRank
+      - mitochondrialContent
+      - mitochondrialReads
+      - classifierContour
+      - genesVsUmisHistogram
+      - genesVsUmisScatterplot
+      - doubletScoreHistogram
+      - dataIntegrationEmbedding
+      - dataIntegrationFrequency
+      - dataIntegrationElbow
+      - embeddingCategorical
+      - embeddingContinuous
+      - embeddingPreviewBySample
+      - embeddingPreviewByCellSets
+      - embeddingPreviewMitochondrialContent
+      - embeddingPreviewDoubletScore
+      - volcano
+      - heatmap
+      - frequency
   config:
     type: object
 required:

--- a/src/specs/models/api-body-schemas/PlotTableConfig.v1.yaml
+++ b/src/specs/models/api-body-schemas/PlotTableConfig.v1.yaml
@@ -1,4 +1,4 @@
-title: 'Plots & Tables configuration'
+title: Plots & Tables configuration
 type: object
 description: A file specifying the configuration for a given plot/table.
 properties:
@@ -8,24 +8,11 @@ properties:
   plotUuid:
     type: string
     description: The UUID of the plot or table.
-  type:
+  plotType:
     type: string
     description: The type of the plot to be saved. Can be one of the values specified herein.
-    enum:
-      - embeddingCategorical
-      - embeddingContinuous
-      - volcano
-      - heatmap
-      - frequency
-      - dataIntegrationEmbedding
-      - dataIntegrationFrequency
-      - dataIntegrationElbow
-      - embeddingPreviewBySample
-      - embeddingPreviewByCellSets
-      - embeddingPreviewMitochondrialContent
-      - embeddingPreviewDoubletScore
   config:
     type: object
 required:
-  - type
+  - plotType
   - config

--- a/src/utils/dynamoDb.js
+++ b/src/utils/dynamoDb.js
@@ -6,7 +6,7 @@ const createDynamoDbInstance = () => new AWS.DynamoDB({
 });
 
 const convertToDynamoDbRecord = (data) => AWS.DynamoDB.Converter.marshall(
-  data, { convertEmptyValues: true },
+  data, { convertEmptyValues: false },
 );
 const convertToJsObject = (data) => AWS.DynamoDB.Converter.unmarshall(data);
 

--- a/tests/api/route-services/pipeline-response.test.js
+++ b/tests/api/route-services/pipeline-response.test.js
@@ -1,0 +1,127 @@
+const AWSMock = require('aws-sdk-mock');
+const ioClient = require('socket.io-client');
+const ioServer = require('socket.io')({
+  allowEIO3: true,
+});
+const AWS = require('../../../src/utils/requireAWS');
+const pipelineResponse = require('../../../src/api/route-services/pipeline-response');
+
+describe('Test Pipeline Response Service', () => {
+  let io;
+  let client;
+
+  const message = {
+    input: {
+      experimentId: '1234',
+      taskName: 'cellSizeDistribution',
+    },
+    output: {
+      bucket: 'aws-bucket',
+      key: '1234',
+    },
+    response: { error: false },
+  };
+
+  const s3output = {
+    Body: JSON.stringify(
+      {
+        config: {
+          enabled: true,
+          filterSettings: {
+            minCellSize: 10800,
+            binStep: 200,
+          },
+        },
+      },
+    ),
+  };
+
+  const experimentId = '1234';
+
+  beforeAll(() => {
+    io = ioServer.listen(3001);
+  });
+
+  beforeEach(() => {
+    AWSMock.setSDKInstance(AWS);
+    client = ioClient.connect('http://localhost:3001', {
+      'reconnection delay': 0,
+      'reopen delay': 0,
+      'force new connection': true,
+      transports: ['websocket'],
+    });
+  });
+
+  afterEach(() => {
+    AWSMock.restore();
+
+    if (client.connected) {
+      client.disconnect();
+    }
+  });
+
+  afterAll(() => {
+    io.close();
+  });
+
+  it('functions propely with correct input', async () => {
+    AWSMock.setSDKInstance(AWS);
+
+    const s3Spy = jest.fn((x) => x);
+    AWSMock.mock('S3', 'getObject', (params, callback) => {
+      s3Spy(params);
+      callback(null, s3output);
+    });
+
+    const dynamoDbSpy = jest.fn((x) => x);
+    AWSMock.mock('DynamoDB', 'updateItem', (params, callback) => {
+      dynamoDbSpy(params);
+      callback(null, {});
+    });
+
+
+    // Expect websocket event
+    client.on(`ExperimentUpdates-${experimentId}`, (res) => {
+      expect(res).toEqual(message);
+    });
+
+    await pipelineResponse(io, message);
+
+    // Download output from S3
+    expect(s3Spy).toHaveBeenCalled();
+
+    // Upload output to DynamoDB
+    // Update processing settings in dynamoDB
+    expect(dynamoDbSpy).toHaveBeenCalled();
+  });
+
+  it('throws error on receiving error in message', async () => {
+    const errorMessage = message;
+    errorMessage.response.error = true;
+
+    AWSMock.setSDKInstance(AWS);
+
+    const s3Spy = jest.fn((x) => x);
+    AWSMock.mock('S3', 'getObject', (params, callback) => {
+      s3Spy(params);
+      callback(null, s3output);
+    });
+
+    const dynamoDbSpy = jest.fn((x) => x);
+    AWSMock.mock('DynamoDB', 'updateItem', (params, callback) => {
+      dynamoDbSpy(params);
+      callback(null, {});
+    });
+
+
+    // Expect websocket event
+    client.on(`ExperimentUpdates-${experimentId}`, (res) => {
+      expect(res).toEqual(message);
+    });
+
+    await pipelineResponse(io, message);
+
+    expect(s3Spy).not.toHaveBeenCalled();
+    expect(dynamoDbSpy).not.toHaveBeenCalled();
+  });
+});

--- a/tests/api/route-services/pipeline-response.test.js
+++ b/tests/api/route-services/pipeline-response.test.js
@@ -116,10 +116,10 @@ describe('Test Pipeline Response Service', () => {
 
     // Expect websocket event
     client.on(`ExperimentUpdates-${experimentId}`, (res) => {
-      expect(res).toEqual(message);
+      expect(res).toEqual(errorMessage);
     });
 
-    await pipelineResponse(io, message);
+    await pipelineResponse(io, errorMessage);
 
     expect(s3Spy).not.toHaveBeenCalled();
     expect(dynamoDbSpy).not.toHaveBeenCalled();


### PR DESCRIPTION
# Background
#### Link to issue 

https://biomage.atlassian.net/browse/BIOMAGE-517

#### Link to staging deployment URL 

Staging link in UI : https://github.com/biomage-ltd/ui/pull/147

#### Links to any Pull Requests related to this

https://github.com/biomage-ltd/ui/pull/147

#### Anything else the reviewers should know about the changes here

- `plotUuid` are still hardcoded in the file. Later on, `plotUuid` should be emitted directly from the QC without hardcoded values in API.
- Does not yet support saving plot configs for multiple samples, as the QC does not yet support multiple samples
- Tested locally with inframock, with capability to upload `plots-tables` table (https://github.com/biomage-ltd/inframock/pull/27)

# Changes
### Code changes

- Added call to DynamoDB in  pipeline response.

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [X] Tested locally with Inframock
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
