### PR TITLE
Remove temp hack used to test before #63 was merged

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,9 @@ aws --endpoint-url=http://localhost:4566 stepfunctions get-execution-history --e
 aws --endpoint-url=http://localhost:4566 stepfunctions describe-state-machine --state-machine-arn arn:aws:states:eu-west-1:...
 ```
 
+One of the test suites creates a snapshot with the definition of the [state machine used in inframock and in non-local
+deployments](https://github.com/biomage-ltd/api/blob/master/tests/api/general-services/__snapshots__/state-machine-definition.test.js.snap).
+
 Deployment
 ----------
 

--- a/src/config/test-config.js
+++ b/src/config/test-config.js
@@ -14,8 +14,7 @@ module.exports = {
   workerNamespace: 'worker-test-namespace',
   pipelineNamespace: 'pipeline-test-namespace',
   workerInstanceConfigUrl: 'https://raw.githubusercontent.com/biomage-ltd/iac/master/releases/production/worker.yaml',
-  // TODO: to be changed once the merged PR is deployed
-  pipelineInstanceConfigUrl: 'https://raw.githubusercontent.com/biomage-ltd/iac/master/releases/staging/xavier-api63-pipeline7-6.yaml',
+  pipelineInstanceConfigUrl: 'https://raw.githubusercontent.com/biomage-ltd/iac/master/releases/production/pipeline.yaml',
   api: {
     prefix: '/',
   },

--- a/tests/api/general-services/__snapshots__/pipeline-manage.test.js.snap
+++ b/tests/api/general-services/__snapshots__/pipeline-manage.test.js.snap
@@ -626,7 +626,7 @@ Array [
                 "chart": Object {
                   "git": "git@github.com:biomage-ltd/pipeline",
                   "path": "remoter-server/chart",
-                  "ref": "debug-jira-650",
+                  "ref": "ebe7a737d28df209dc63b9345943861ca744a725",
                 },
                 "releaseName": "remoter-server-testExperimentId",
                 "values": Object {


### PR DESCRIPTION
# Background
#### Link to issue 

N/A

#### Link to staging deployment URL 

N/A

#### Links to any Pull Requests related to this

#63 

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

Tests had to point to a staging environment configuration file, because it was not still available in production.
Now it is, and the hack has been undone.

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [x] Unit tests written
- [ ] Tested locally with Inframock
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [x] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [x] Photo of a cute animal attached to this PR
![octopus](https://user-images.githubusercontent.com/460418/111655386-e56ad880-8809-11eb-9ca1-7327897c5722.jpg)
]