### PR TITLE
Fixed the generation of the snapshots that document the state machines

### DIFF
--- a/tests/api/general-services/__snapshots__/state-machine-definition.test.js.snap
+++ b/tests/api/general-services/__snapshots__/state-machine-definition.test.js.snap
@@ -295,6 +295,7 @@ exports[`non-tests to document the State Machines -cloud 1`] = `
             },
             "values": {
               "experimentId": "mock-experiment-id",
+              "image": "mock-remoter-server-image",
               "namespace": "pipeline-test-namespace",
               "awsAccountId": "mock-account-id",
               "clusterEnv": "test",
@@ -368,6 +369,7 @@ exports[`non-tests to document the State Machines -cloud 1`] = `
                       "containers": [
                         {
                           "name": "remoter-client",
+                          "image": "mock-remoter-client-image",
                           "args": [
                             "{\\"experimentId\\":\\"mock-experiment-id\\",\\"taskName\\":\\"cellSizeDistribution\\",\\"config\\":{},\\"server\\":\\"remoter-server-mock-experiment-id.pipeline-test-namespace.svc.cluster.local\\"}"
                           ],
@@ -442,6 +444,7 @@ exports[`non-tests to document the State Machines -cloud 1`] = `
                       "containers": [
                         {
                           "name": "remoter-client",
+                          "image": "mock-remoter-client-image",
                           "args": [
                             "{\\"experimentId\\":\\"mock-experiment-id\\",\\"taskName\\":\\"mitochondrialContent\\",\\"config\\":{},\\"server\\":\\"remoter-server-mock-experiment-id.pipeline-test-namespace.svc.cluster.local\\"}"
                           ],
@@ -516,6 +519,7 @@ exports[`non-tests to document the State Machines -cloud 1`] = `
                       "containers": [
                         {
                           "name": "remoter-client",
+                          "image": "mock-remoter-client-image",
                           "args": [
                             "{\\"experimentId\\":\\"mock-experiment-id\\",\\"taskName\\":\\"classifier\\",\\"config\\":{},\\"server\\":\\"remoter-server-mock-experiment-id.pipeline-test-namespace.svc.cluster.local\\"}"
                           ],
@@ -590,6 +594,7 @@ exports[`non-tests to document the State Machines -cloud 1`] = `
                       "containers": [
                         {
                           "name": "remoter-client",
+                          "image": "mock-remoter-client-image",
                           "args": [
                             "{\\"experimentId\\":\\"mock-experiment-id\\",\\"taskName\\":\\"numGenesVsNumUmis\\",\\"config\\":{},\\"server\\":\\"remoter-server-mock-experiment-id.pipeline-test-namespace.svc.cluster.local\\"}"
                           ],
@@ -664,6 +669,7 @@ exports[`non-tests to document the State Machines -cloud 1`] = `
                       "containers": [
                         {
                           "name": "remoter-client",
+                          "image": "mock-remoter-client-image",
                           "args": [
                             "{\\"experimentId\\":\\"mock-experiment-id\\",\\"taskName\\":\\"doubletScores\\",\\"config\\":{},\\"server\\":\\"remoter-server-mock-experiment-id.pipeline-test-namespace.svc.cluster.local\\"}"
                           ],
@@ -745,6 +751,7 @@ exports[`non-tests to document the State Machines -cloud 1`] = `
                 "containers": [
                   {
                     "name": "remoter-client",
+                    "image": "mock-remoter-client-image",
                     "args": [
                       "{\\"experimentId\\":\\"mock-experiment-id\\",\\"taskName\\":\\"dataIntegration\\",\\"config\\":{},\\"server\\":\\"remoter-server-mock-experiment-id.pipeline-test-namespace.svc.cluster.local\\"}"
                     ],
@@ -819,6 +826,7 @@ exports[`non-tests to document the State Machines -cloud 1`] = `
                 "containers": [
                   {
                     "name": "remoter-client",
+                    "image": "mock-remoter-client-image",
                     "args": [
                       "{\\"experimentId\\":\\"mock-experiment-id\\",\\"taskName\\":\\"configureEmbedding\\",\\"config\\":{},\\"server\\":\\"remoter-server-mock-experiment-id.pipeline-test-namespace.svc.cluster.local\\"}"
                     ],

--- a/tests/api/general-services/state-machine-definition.test.js
+++ b/tests/api/general-services/state-machine-definition.test.js
@@ -24,10 +24,8 @@ describe('non-tests to document the State Machines', () => {
     accountId: 'mock-account-id',
     roleArn: 'mock-role-arn',
     pipelineArtifacts: {
-      images: {
-        'remoter-server': 'mock-remoter-server-image',
-        'remoter-client': 'mock-remoter-client-image',
-      },
+      'remoter-server': 'mock-remoter-server-image',
+      'remoter-client': 'mock-remoter-client-image',
     },
     clusterInfo: {
       name: 'mock-cluster-name',


### PR DESCRIPTION
# Background
#### Link to issue 

N/A

#### Link to staging deployment URL 

N/A

#### Links to any Pull Requests related to this

N/A

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

Fixed the generation of the snapshots that document the state machines, that was missing the Job images.

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
