### PR TITLE
Make jobs created by pipeline unique per map iteration

### DIFF
--- a/src/api/general-services/pipeline-manage/constructors/create-new-step.js
+++ b/src/api/general-services/pipeline-manage/constructors/create-new-step.js
@@ -38,7 +38,7 @@ const createNewStep = (context, step, args) => {
         FunctionName: `arn:aws:lambda:eu-west-1:${accountId}:function:local-container-launcher`,
         Payload: {
           image: 'biomage-remoter-client',
-          name: 'pipeline-remoter-client',
+          'name.$': 'States.Format(\'pipeline-remoter-client-{}\', $.sampleUuid)',
           task,
           'sampleUuid.$': '$.sampleUuid',
           detached: false,
@@ -75,7 +75,7 @@ const createNewStep = (context, step, args) => {
         apiVersion: 'batch/v1',
         kind: 'Job',
         metadata: {
-          name: `remoter-client-${stepHash}`,
+          'name.$': `States.Format('remoter-client-${stepHash}-{}', $.sampleUuid)`,
           labels: {
             sandboxId: config.sandboxId,
             experimentId,
@@ -86,7 +86,7 @@ const createNewStep = (context, step, args) => {
         spec: {
           template: {
             metadata: {
-              name: `remoter-client-${experimentId}`,
+              'name.$': `States.Format('remoter-client-${stepHash}-{}', $.sampleUuid)`,
               labels: {
                 sandboxId: config.sandboxId,
                 type: 'pipeline',

--- a/tests/api/general-services/__snapshots__/pipeline-manage.test.js.snap
+++ b/tests/api/general-services/__snapshots__/pipeline-manage.test.js.snap
@@ -96,7 +96,7 @@ Array [
                   "taskName": "configureEmbedding",
                   "type": "pipeline",
                 },
-                "name": "remoter-client-54f9fbc3f96a7220744a6e068d1dbfb604b3e773",
+                "name.$": "States.Format('remoter-client-54f9fbc3f96a7220744a6e068d1dbfb604b3e773-{}', $.sampleUuid)",
               },
               "spec": Object {
                 "template": Object {
@@ -104,7 +104,7 @@ Array [
                     "labels": Object {
                       "type": "pipeline",
                     },
-                    "name": "remoter-client-testExperimentId",
+                    "name.$": "States.Format('remoter-client-54f9fbc3f96a7220744a6e068d1dbfb604b3e773-{}', $.sampleUuid)",
                   },
                   "spec": Object {
                     "containers": Array [
@@ -171,7 +171,7 @@ Array [
                   "taskName": "dataIntegration",
                   "type": "pipeline",
                 },
-                "name": "remoter-client-54f9fbc3f96a7220744a6e068d1dbfb604b3e773",
+                "name.$": "States.Format('remoter-client-54f9fbc3f96a7220744a6e068d1dbfb604b3e773-{}', $.sampleUuid)",
               },
               "spec": Object {
                 "template": Object {
@@ -179,7 +179,7 @@ Array [
                     "labels": Object {
                       "type": "pipeline",
                     },
-                    "name": "remoter-client-testExperimentId",
+                    "name.$": "States.Format('remoter-client-54f9fbc3f96a7220744a6e068d1dbfb604b3e773-{}', $.sampleUuid)",
                   },
                   "spec": Object {
                     "containers": Array [
@@ -274,7 +274,7 @@ Array [
                         "taskName": "cellSizeDistribution",
                         "type": "pipeline",
                       },
-                      "name": "remoter-client-54f9fbc3f96a7220744a6e068d1dbfb604b3e773",
+                      "name.$": "States.Format('remoter-client-54f9fbc3f96a7220744a6e068d1dbfb604b3e773-{}', $.sampleUuid)",
                     },
                     "spec": Object {
                       "template": Object {
@@ -282,7 +282,7 @@ Array [
                           "labels": Object {
                             "type": "pipeline",
                           },
-                          "name": "remoter-client-testExperimentId",
+                          "name.$": "States.Format('remoter-client-54f9fbc3f96a7220744a6e068d1dbfb604b3e773-{}', $.sampleUuid)",
                         },
                         "spec": Object {
                           "containers": Array [
@@ -349,7 +349,7 @@ Array [
                         "taskName": "classifier",
                         "type": "pipeline",
                       },
-                      "name": "remoter-client-54f9fbc3f96a7220744a6e068d1dbfb604b3e773",
+                      "name.$": "States.Format('remoter-client-54f9fbc3f96a7220744a6e068d1dbfb604b3e773-{}', $.sampleUuid)",
                     },
                     "spec": Object {
                       "template": Object {
@@ -357,7 +357,7 @@ Array [
                           "labels": Object {
                             "type": "pipeline",
                           },
-                          "name": "remoter-client-testExperimentId",
+                          "name.$": "States.Format('remoter-client-54f9fbc3f96a7220744a6e068d1dbfb604b3e773-{}', $.sampleUuid)",
                         },
                         "spec": Object {
                           "containers": Array [
@@ -424,7 +424,7 @@ Array [
                         "taskName": "doubletScores",
                         "type": "pipeline",
                       },
-                      "name": "remoter-client-54f9fbc3f96a7220744a6e068d1dbfb604b3e773",
+                      "name.$": "States.Format('remoter-client-54f9fbc3f96a7220744a6e068d1dbfb604b3e773-{}', $.sampleUuid)",
                     },
                     "spec": Object {
                       "template": Object {
@@ -432,7 +432,7 @@ Array [
                           "labels": Object {
                             "type": "pipeline",
                           },
-                          "name": "remoter-client-testExperimentId",
+                          "name.$": "States.Format('remoter-client-54f9fbc3f96a7220744a6e068d1dbfb604b3e773-{}', $.sampleUuid)",
                         },
                         "spec": Object {
                           "containers": Array [
@@ -503,7 +503,7 @@ Array [
                         "taskName": "mitochondrialContent",
                         "type": "pipeline",
                       },
-                      "name": "remoter-client-54f9fbc3f96a7220744a6e068d1dbfb604b3e773",
+                      "name.$": "States.Format('remoter-client-54f9fbc3f96a7220744a6e068d1dbfb604b3e773-{}', $.sampleUuid)",
                     },
                     "spec": Object {
                       "template": Object {
@@ -511,7 +511,7 @@ Array [
                           "labels": Object {
                             "type": "pipeline",
                           },
-                          "name": "remoter-client-testExperimentId",
+                          "name.$": "States.Format('remoter-client-54f9fbc3f96a7220744a6e068d1dbfb604b3e773-{}', $.sampleUuid)",
                         },
                         "spec": Object {
                           "containers": Array [
@@ -578,7 +578,7 @@ Array [
                         "taskName": "numGenesVsNumUmis",
                         "type": "pipeline",
                       },
-                      "name": "remoter-client-54f9fbc3f96a7220744a6e068d1dbfb604b3e773",
+                      "name.$": "States.Format('remoter-client-54f9fbc3f96a7220744a6e068d1dbfb604b3e773-{}', $.sampleUuid)",
                     },
                     "spec": Object {
                       "template": Object {
@@ -586,7 +586,7 @@ Array [
                           "labels": Object {
                             "type": "pipeline",
                           },
-                          "name": "remoter-client-testExperimentId",
+                          "name.$": "States.Format('remoter-client-54f9fbc3f96a7220744a6e068d1dbfb604b3e773-{}', $.sampleUuid)",
                         },
                         "spec": Object {
                           "containers": Array [

--- a/tests/api/general-services/__snapshots__/state-machine-definition.test.js.snap
+++ b/tests/api/general-services/__snapshots__/state-machine-definition.test.js.snap
@@ -56,7 +56,7 @@ exports[`non-tests to document the State Machines - local development 1`] = `
               "FunctionName": "arn:aws:lambda:eu-west-1:mock-account-id:function:local-container-launcher",
               "Payload": {
                 "image": "biomage-remoter-client",
-                "name": "pipeline-remoter-client",
+                "name.$": "States.Format('pipeline-remoter-client-{}', $.sampleUuid)",
                 "task": "{\\"experimentId\\":\\"mock-experiment-id\\",\\"taskName\\":\\"cellSizeDistribution\\",\\"config\\":{},\\"server\\":\\"host.docker.internal\\"}",
                 "sampleUuid.$": "$.sampleUuid",
                 "detached": false
@@ -81,7 +81,7 @@ exports[`non-tests to document the State Machines - local development 1`] = `
               "FunctionName": "arn:aws:lambda:eu-west-1:mock-account-id:function:local-container-launcher",
               "Payload": {
                 "image": "biomage-remoter-client",
-                "name": "pipeline-remoter-client",
+                "name.$": "States.Format('pipeline-remoter-client-{}', $.sampleUuid)",
                 "task": "{\\"experimentId\\":\\"mock-experiment-id\\",\\"taskName\\":\\"mitochondrialContent\\",\\"config\\":{},\\"server\\":\\"host.docker.internal\\"}",
                 "sampleUuid.$": "$.sampleUuid",
                 "detached": false
@@ -106,7 +106,7 @@ exports[`non-tests to document the State Machines - local development 1`] = `
               "FunctionName": "arn:aws:lambda:eu-west-1:mock-account-id:function:local-container-launcher",
               "Payload": {
                 "image": "biomage-remoter-client",
-                "name": "pipeline-remoter-client",
+                "name.$": "States.Format('pipeline-remoter-client-{}', $.sampleUuid)",
                 "task": "{\\"experimentId\\":\\"mock-experiment-id\\",\\"taskName\\":\\"classifier\\",\\"config\\":{},\\"server\\":\\"host.docker.internal\\"}",
                 "sampleUuid.$": "$.sampleUuid",
                 "detached": false
@@ -131,7 +131,7 @@ exports[`non-tests to document the State Machines - local development 1`] = `
               "FunctionName": "arn:aws:lambda:eu-west-1:mock-account-id:function:local-container-launcher",
               "Payload": {
                 "image": "biomage-remoter-client",
-                "name": "pipeline-remoter-client",
+                "name.$": "States.Format('pipeline-remoter-client-{}', $.sampleUuid)",
                 "task": "{\\"experimentId\\":\\"mock-experiment-id\\",\\"taskName\\":\\"numGenesVsNumUmis\\",\\"config\\":{},\\"server\\":\\"host.docker.internal\\"}",
                 "sampleUuid.$": "$.sampleUuid",
                 "detached": false
@@ -156,7 +156,7 @@ exports[`non-tests to document the State Machines - local development 1`] = `
               "FunctionName": "arn:aws:lambda:eu-west-1:mock-account-id:function:local-container-launcher",
               "Payload": {
                 "image": "biomage-remoter-client",
-                "name": "pipeline-remoter-client",
+                "name.$": "States.Format('pipeline-remoter-client-{}', $.sampleUuid)",
                 "task": "{\\"experimentId\\":\\"mock-experiment-id\\",\\"taskName\\":\\"doubletScores\\",\\"config\\":{},\\"server\\":\\"host.docker.internal\\"}",
                 "sampleUuid.$": "$.sampleUuid",
                 "detached": false
@@ -188,7 +188,7 @@ exports[`non-tests to document the State Machines - local development 1`] = `
         "FunctionName": "arn:aws:lambda:eu-west-1:mock-account-id:function:local-container-launcher",
         "Payload": {
           "image": "biomage-remoter-client",
-          "name": "pipeline-remoter-client",
+          "name.$": "States.Format('pipeline-remoter-client-{}', $.sampleUuid)",
           "task": "{\\"experimentId\\":\\"mock-experiment-id\\",\\"taskName\\":\\"dataIntegration\\",\\"config\\":{},\\"server\\":\\"host.docker.internal\\"}",
           "sampleUuid.$": "$.sampleUuid",
           "detached": false
@@ -213,7 +213,7 @@ exports[`non-tests to document the State Machines - local development 1`] = `
         "FunctionName": "arn:aws:lambda:eu-west-1:mock-account-id:function:local-container-launcher",
         "Payload": {
           "image": "biomage-remoter-client",
-          "name": "pipeline-remoter-client",
+          "name.$": "States.Format('pipeline-remoter-client-{}', $.sampleUuid)",
           "task": "{\\"experimentId\\":\\"mock-experiment-id\\",\\"taskName\\":\\"configureEmbedding\\",\\"config\\":{},\\"server\\":\\"host.docker.internal\\"}",
           "sampleUuid.$": "$.sampleUuid",
           "detached": false
@@ -350,7 +350,7 @@ exports[`non-tests to document the State Machines -cloud 1`] = `
                 "apiVersion": "batch/v1",
                 "kind": "Job",
                 "metadata": {
-                  "name": "remoter-client-8d82349945fc652555261e7d10f0b9b8b4942f27",
+                  "name.$": "States.Format('remoter-client-8d82349945fc652555261e7d10f0b9b8b4942f27-{}', $.sampleUuid)",
                   "labels": {
                     "experimentId": "mock-experiment-id",
                     "taskName": "cellSizeDistribution",
@@ -360,7 +360,7 @@ exports[`non-tests to document the State Machines -cloud 1`] = `
                 "spec": {
                   "template": {
                     "metadata": {
-                      "name": "remoter-client-mock-experiment-id",
+                      "name.$": "States.Format('remoter-client-8d82349945fc652555261e7d10f0b9b8b4942f27-{}', $.sampleUuid)",
                       "labels": {
                         "type": "pipeline"
                       }
@@ -425,7 +425,7 @@ exports[`non-tests to document the State Machines -cloud 1`] = `
                 "apiVersion": "batch/v1",
                 "kind": "Job",
                 "metadata": {
-                  "name": "remoter-client-8d82349945fc652555261e7d10f0b9b8b4942f27",
+                  "name.$": "States.Format('remoter-client-8d82349945fc652555261e7d10f0b9b8b4942f27-{}', $.sampleUuid)",
                   "labels": {
                     "experimentId": "mock-experiment-id",
                     "taskName": "mitochondrialContent",
@@ -435,7 +435,7 @@ exports[`non-tests to document the State Machines -cloud 1`] = `
                 "spec": {
                   "template": {
                     "metadata": {
-                      "name": "remoter-client-mock-experiment-id",
+                      "name.$": "States.Format('remoter-client-8d82349945fc652555261e7d10f0b9b8b4942f27-{}', $.sampleUuid)",
                       "labels": {
                         "type": "pipeline"
                       }
@@ -500,7 +500,7 @@ exports[`non-tests to document the State Machines -cloud 1`] = `
                 "apiVersion": "batch/v1",
                 "kind": "Job",
                 "metadata": {
-                  "name": "remoter-client-8d82349945fc652555261e7d10f0b9b8b4942f27",
+                  "name.$": "States.Format('remoter-client-8d82349945fc652555261e7d10f0b9b8b4942f27-{}', $.sampleUuid)",
                   "labels": {
                     "experimentId": "mock-experiment-id",
                     "taskName": "classifier",
@@ -510,7 +510,7 @@ exports[`non-tests to document the State Machines -cloud 1`] = `
                 "spec": {
                   "template": {
                     "metadata": {
-                      "name": "remoter-client-mock-experiment-id",
+                      "name.$": "States.Format('remoter-client-8d82349945fc652555261e7d10f0b9b8b4942f27-{}', $.sampleUuid)",
                       "labels": {
                         "type": "pipeline"
                       }
@@ -575,7 +575,7 @@ exports[`non-tests to document the State Machines -cloud 1`] = `
                 "apiVersion": "batch/v1",
                 "kind": "Job",
                 "metadata": {
-                  "name": "remoter-client-8d82349945fc652555261e7d10f0b9b8b4942f27",
+                  "name.$": "States.Format('remoter-client-8d82349945fc652555261e7d10f0b9b8b4942f27-{}', $.sampleUuid)",
                   "labels": {
                     "experimentId": "mock-experiment-id",
                     "taskName": "numGenesVsNumUmis",
@@ -585,7 +585,7 @@ exports[`non-tests to document the State Machines -cloud 1`] = `
                 "spec": {
                   "template": {
                     "metadata": {
-                      "name": "remoter-client-mock-experiment-id",
+                      "name.$": "States.Format('remoter-client-8d82349945fc652555261e7d10f0b9b8b4942f27-{}', $.sampleUuid)",
                       "labels": {
                         "type": "pipeline"
                       }
@@ -650,7 +650,7 @@ exports[`non-tests to document the State Machines -cloud 1`] = `
                 "apiVersion": "batch/v1",
                 "kind": "Job",
                 "metadata": {
-                  "name": "remoter-client-8d82349945fc652555261e7d10f0b9b8b4942f27",
+                  "name.$": "States.Format('remoter-client-8d82349945fc652555261e7d10f0b9b8b4942f27-{}', $.sampleUuid)",
                   "labels": {
                     "experimentId": "mock-experiment-id",
                     "taskName": "doubletScores",
@@ -660,7 +660,7 @@ exports[`non-tests to document the State Machines -cloud 1`] = `
                 "spec": {
                   "template": {
                     "metadata": {
-                      "name": "remoter-client-mock-experiment-id",
+                      "name.$": "States.Format('remoter-client-8d82349945fc652555261e7d10f0b9b8b4942f27-{}', $.sampleUuid)",
                       "labels": {
                         "type": "pipeline"
                       }
@@ -732,7 +732,7 @@ exports[`non-tests to document the State Machines -cloud 1`] = `
           "apiVersion": "batch/v1",
           "kind": "Job",
           "metadata": {
-            "name": "remoter-client-8d82349945fc652555261e7d10f0b9b8b4942f27",
+            "name.$": "States.Format('remoter-client-8d82349945fc652555261e7d10f0b9b8b4942f27-{}', $.sampleUuid)",
             "labels": {
               "experimentId": "mock-experiment-id",
               "taskName": "dataIntegration",
@@ -742,7 +742,7 @@ exports[`non-tests to document the State Machines -cloud 1`] = `
           "spec": {
             "template": {
               "metadata": {
-                "name": "remoter-client-mock-experiment-id",
+                "name.$": "States.Format('remoter-client-8d82349945fc652555261e7d10f0b9b8b4942f27-{}', $.sampleUuid)",
                 "labels": {
                   "type": "pipeline"
                 }
@@ -807,7 +807,7 @@ exports[`non-tests to document the State Machines -cloud 1`] = `
           "apiVersion": "batch/v1",
           "kind": "Job",
           "metadata": {
-            "name": "remoter-client-8d82349945fc652555261e7d10f0b9b8b4942f27",
+            "name.$": "States.Format('remoter-client-8d82349945fc652555261e7d10f0b9b8b4942f27-{}', $.sampleUuid)",
             "labels": {
               "experimentId": "mock-experiment-id",
               "taskName": "configureEmbedding",
@@ -817,7 +817,7 @@ exports[`non-tests to document the State Machines -cloud 1`] = `
           "spec": {
             "template": {
               "metadata": {
-                "name": "remoter-client-mock-experiment-id",
+                "name.$": "States.Format('remoter-client-8d82349945fc652555261e7d10f0b9b8b4942f27-{}', $.sampleUuid)",
                 "labels": {
                   "type": "pipeline"
                 }


### PR DESCRIPTION
# Background
#### Link to issue 
https://biomage.atlassian.net/browse/BIOMAGE-521

#### Link to staging deployment URL 
TBD

#### Links to any Pull Requests related to this
N/A

#### Anything else the reviewers should know about the changes here
N/A

# Changes
### Code changes
This is a partial fix to make API and UI handle multisample correctly. Jobs are created so their names are unique per iteration, so there is no name collision.

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [x] Unit tests written
- [x] Tested locally with Inframock
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [x] Relevant Github READMEs updated
- [x] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
