### PR TITLE
Fix api reporting on initial setup steps not relevant to the ui

### DIFF
--- a/src/api/general-services/pipeline-status.js
+++ b/src/api/general-services/pipeline-status.js
@@ -1,7 +1,11 @@
+const _ = require('lodash');
 const AWS = require('../../utils/requireAWS');
 const ExperimentService = require('../route-services/experiment');
 const config = require('../../config');
 const logger = require('../../utils/logging');
+
+
+const privateSteps = ['DeleteCompletedPipelineWorker', 'LaunchNewPipelineWorker'];
 
 const getStepsFromExecutionHistory = (history) => {
   const { events } = history;
@@ -83,8 +87,12 @@ const getStepsFromExecutionHistory = (history) => {
       }
     }
   }
+
   shortestCompleted = (shortestCompleted || []).concat(main.completedTasks);
-  return shortestCompleted || [];
+
+  const shortestCompletedToReport = _.difference(shortestCompleted, privateSteps);
+
+  return shortestCompletedToReport || [];
 };
 
 /*


### PR DESCRIPTION
# Background
#### Link to issue 

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here
The api was returning not only the normal steps but also the two initial setup steps: `DeleteCompletedPipelineWorker` 
 and `LaunchNewPipelineWorker`

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [x] Tested locally with Inframock
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
