### PR TITLE
Set classifier as first filter

### DIFF
--- a/src/api/general-services/pipeline-manage/index.js
+++ b/src/api/general-services/pipeline-manage/index.js
@@ -136,8 +136,16 @@ const buildStateMachineDefinition = (context) => {
         MaxConcurrency: 1,
         ItemsPath: '$.samples',
         Iterator: {
-          StartAt: 'CellSizeDistributionFilter',
+          StartAt: 'ClassifierFilter',
           States: {
+            ClassifierFilter: {
+              XStepType: 'create-new-step',
+              XConstructorArgs: {
+                perSample: true,
+                taskName: 'classifier',
+              },
+              Next: 'CellSizeDistributionFilter',
+            },
             CellSizeDistributionFilter: {
               XStepType: 'create-new-step',
               XConstructorArgs: {
@@ -151,14 +159,6 @@ const buildStateMachineDefinition = (context) => {
               XConstructorArgs: {
                 perSample: true,
                 taskName: 'mitochondrialContent',
-              },
-              Next: 'ClassifierFilter',
-            },
-            ClassifierFilter: {
-              XStepType: 'create-new-step',
-              XConstructorArgs: {
-                perSample: true,
-                taskName: 'classifier',
               },
               Next: 'NumGenesVsNumUmisFilter',
             },

--- a/tests/api/general-services/__snapshots__/pipeline-manage.test.js.snap
+++ b/tests/api/general-services/__snapshots__/pipeline-manage.test.js.snap
@@ -247,7 +247,7 @@ Array [
         "Filters": Object {
           "ItemsPath": "$.samples",
           "Iterator": Object {
-            "StartAt": "CellSizeDistributionFilter",
+            "StartAt": "ClassifierFilter",
             "States": Object {
               "CellSizeDistributionFilter": Object {
                 "Catch": Array [
@@ -330,12 +330,12 @@ Array [
                     "ErrorEquals": Array [
                       "EKS.409",
                     ],
-                    "Next": "NumGenesVsNumUmisFilter",
+                    "Next": "CellSizeDistributionFilter",
                     "ResultPath": "$.error-info",
                   },
                 ],
                 "Comment": "Attempts to create a Kubernetes Job for the pipeline server. Will swallow a 409 (already exists) error.",
-                "Next": "NumGenesVsNumUmisFilter",
+                "Next": "CellSizeDistributionFilter",
                 "Parameters": Object {
                   "CertificateAuthority": "AAAAAAAAAAA",
                   "ClusterName": "biomage-test",
@@ -484,12 +484,12 @@ Array [
                     "ErrorEquals": Array [
                       "EKS.409",
                     ],
-                    "Next": "ClassifierFilter",
+                    "Next": "NumGenesVsNumUmisFilter",
                     "ResultPath": "$.error-info",
                   },
                 ],
                 "Comment": "Attempts to create a Kubernetes Job for the pipeline server. Will swallow a 409 (already exists) error.",
-                "Next": "ClassifierFilter",
+                "Next": "NumGenesVsNumUmisFilter",
                 "Parameters": Object {
                   "CertificateAuthority": "AAAAAAAAAAA",
                   "ClusterName": "biomage-test",

--- a/tests/api/general-services/__snapshots__/state-machine-definition.test.js.snap
+++ b/tests/api/general-services/__snapshots__/state-machine-definition.test.js.snap
@@ -45,8 +45,33 @@ exports[`non-tests to document the State Machines - local development 1`] = `
       "MaxConcurrency": 1,
       "ItemsPath": "$.samples",
       "Iterator": {
-        "StartAt": "CellSizeDistributionFilter",
+        "StartAt": "ClassifierFilter",
         "States": {
+          "ClassifierFilter": {
+            "Next": "CellSizeDistributionFilter",
+            "Type": "Task",
+            "Resource": "arn:aws:states:::lambda:invoke",
+            "ResultPath": null,
+            "Parameters": {
+              "FunctionName": "arn:aws:lambda:eu-west-1:mock-account-id:function:local-container-launcher",
+              "Payload": {
+                "image": "biomage-remoter-client",
+                "name": "pipeline-remoter-client",
+                "task": "{\\"experimentId\\":\\"mock-experiment-id\\",\\"taskName\\":\\"classifier\\",\\"config\\":{},\\"server\\":\\"host.docker.internal\\"}",
+                "sampleUuid.$": "$.sampleUuid",
+                "detached": false
+              }
+            },
+            "Catch": [
+              {
+                "ErrorEquals": [
+                  "States.ALL"
+                ],
+                "ResultPath": "$.error-info",
+                "Next": "CellSizeDistributionFilter"
+              }
+            ]
+          },
           "CellSizeDistributionFilter": {
             "Next": "MitochondrialContentFilter",
             "Type": "Task",
@@ -73,31 +98,6 @@ exports[`non-tests to document the State Machines - local development 1`] = `
             ]
           },
           "MitochondrialContentFilter": {
-            "Next": "ClassifierFilter",
-            "Type": "Task",
-            "Resource": "arn:aws:states:::lambda:invoke",
-            "ResultPath": null,
-            "Parameters": {
-              "FunctionName": "arn:aws:lambda:eu-west-1:mock-account-id:function:local-container-launcher",
-              "Payload": {
-                "image": "biomage-remoter-client",
-                "name": "pipeline-remoter-client",
-                "task": "{\\"experimentId\\":\\"mock-experiment-id\\",\\"taskName\\":\\"mitochondrialContent\\",\\"config\\":{},\\"server\\":\\"host.docker.internal\\"}",
-                "sampleUuid.$": "$.sampleUuid",
-                "detached": false
-              }
-            },
-            "Catch": [
-              {
-                "ErrorEquals": [
-                  "States.ALL"
-                ],
-                "ResultPath": "$.error-info",
-                "Next": "ClassifierFilter"
-              }
-            ]
-          },
-          "ClassifierFilter": {
             "Next": "NumGenesVsNumUmisFilter",
             "Type": "Task",
             "Resource": "arn:aws:states:::lambda:invoke",
@@ -107,7 +107,7 @@ exports[`non-tests to document the State Machines - local development 1`] = `
               "Payload": {
                 "image": "biomage-remoter-client",
                 "name": "pipeline-remoter-client",
-                "task": "{\\"experimentId\\":\\"mock-experiment-id\\",\\"taskName\\":\\"classifier\\",\\"config\\":{},\\"server\\":\\"host.docker.internal\\"}",
+                "task": "{\\"experimentId\\":\\"mock-experiment-id\\",\\"taskName\\":\\"mitochondrialContent\\",\\"config\\":{},\\"server\\":\\"host.docker.internal\\"}",
                 "sampleUuid.$": "$.sampleUuid",
                 "detached": false
               }
@@ -330,8 +330,83 @@ exports[`non-tests to document the State Machines -cloud 1`] = `
       "MaxConcurrency": 1,
       "ItemsPath": "$.samples",
       "Iterator": {
-        "StartAt": "CellSizeDistributionFilter",
+        "StartAt": "ClassifierFilter",
         "States": {
+          "ClassifierFilter": {
+            "Next": "CellSizeDistributionFilter",
+            "Type": "Task",
+            "Comment": "Attempts to create a Kubernetes Job for the pipeline server. Will swallow a 409 (already exists) error.",
+            "Resource": "arn:aws:states:::eks:runJob.sync",
+            "ResultPath": null,
+            "Parameters": {
+              "ClusterName": "mock-cluster-name",
+              "CertificateAuthority": "mock-ca",
+              "Endpoint": "mock-endpoint",
+              "Namespace": "pipeline-test-namespace",
+              "LogOptions": {
+                "RetrieveLogs": true
+              },
+              "Job": {
+                "apiVersion": "batch/v1",
+                "kind": "Job",
+                "metadata": {
+                  "name.$": "States.Format('remoter-client-6173646667-{}', $.index)",
+                  "labels": {
+                    "experimentId": "mock-experiment-id",
+                    "taskName": "classifier",
+                    "type": "pipeline"
+                  }
+                },
+                "spec": {
+                  "template": {
+                    "metadata": {
+                      "name.$": "States.Format('remoter-client-6173646667-{}', $.index)",
+                      "labels": {
+                        "type": "pipeline"
+                      }
+                    },
+                    "spec": {
+                      "containers": [
+                        {
+                          "name": "remoter-client",
+                          "image": "mock-remoter-client-image",
+                          "args": [
+                            "{\\"experimentId\\":\\"mock-experiment-id\\",\\"taskName\\":\\"classifier\\",\\"config\\":{},\\"server\\":\\"remoter-server-mock-experiment-id.pipeline-test-namespace.svc.cluster.local\\"}"
+                          ],
+                          "env": [
+                            {
+                              "name": "SAMPLE_ID",
+                              "value.$": "$.sampleUuid"
+                            }
+                          ]
+                        }
+                      ],
+                      "restartPolicy": "Never"
+                    }
+                  }
+                }
+              }
+            },
+            "Retry": [
+              {
+                "ErrorEquals": [
+                  "EKS.409"
+                ],
+                "IntervalSeconds": 1,
+                "BackoffRate": 2,
+                "MaxAttempts": 2
+              }
+            ],
+            "Catch": [
+              {
+                "ErrorEquals": [
+                  "EKS.409"
+                ],
+                "ResultPath": "$.error-info",
+                "Next": "CellSizeDistributionFilter"
+              }
+            ]
+          },
           "CellSizeDistributionFilter": {
             "Next": "MitochondrialContentFilter",
             "Type": "Task",
@@ -408,7 +483,7 @@ exports[`non-tests to document the State Machines -cloud 1`] = `
             ]
           },
           "MitochondrialContentFilter": {
-            "Next": "ClassifierFilter",
+            "Next": "NumGenesVsNumUmisFilter",
             "Type": "Task",
             "Comment": "Attempts to create a Kubernetes Job for the pipeline server. Will swallow a 409 (already exists) error.",
             "Resource": "arn:aws:states:::eks:runJob.sync",
@@ -447,81 +522,6 @@ exports[`non-tests to document the State Machines -cloud 1`] = `
                           "image": "mock-remoter-client-image",
                           "args": [
                             "{\\"experimentId\\":\\"mock-experiment-id\\",\\"taskName\\":\\"mitochondrialContent\\",\\"config\\":{},\\"server\\":\\"remoter-server-mock-experiment-id.pipeline-test-namespace.svc.cluster.local\\"}"
-                          ],
-                          "env": [
-                            {
-                              "name": "SAMPLE_ID",
-                              "value.$": "$.sampleUuid"
-                            }
-                          ]
-                        }
-                      ],
-                      "restartPolicy": "Never"
-                    }
-                  }
-                }
-              }
-            },
-            "Retry": [
-              {
-                "ErrorEquals": [
-                  "EKS.409"
-                ],
-                "IntervalSeconds": 1,
-                "BackoffRate": 2,
-                "MaxAttempts": 2
-              }
-            ],
-            "Catch": [
-              {
-                "ErrorEquals": [
-                  "EKS.409"
-                ],
-                "ResultPath": "$.error-info",
-                "Next": "ClassifierFilter"
-              }
-            ]
-          },
-          "ClassifierFilter": {
-            "Next": "NumGenesVsNumUmisFilter",
-            "Type": "Task",
-            "Comment": "Attempts to create a Kubernetes Job for the pipeline server. Will swallow a 409 (already exists) error.",
-            "Resource": "arn:aws:states:::eks:runJob.sync",
-            "ResultPath": null,
-            "Parameters": {
-              "ClusterName": "mock-cluster-name",
-              "CertificateAuthority": "mock-ca",
-              "Endpoint": "mock-endpoint",
-              "Namespace": "pipeline-test-namespace",
-              "LogOptions": {
-                "RetrieveLogs": true
-              },
-              "Job": {
-                "apiVersion": "batch/v1",
-                "kind": "Job",
-                "metadata": {
-                  "name.$": "States.Format('remoter-client-6173646667-{}', $.index)",
-                  "labels": {
-                    "experimentId": "mock-experiment-id",
-                    "taskName": "classifier",
-                    "type": "pipeline"
-                  }
-                },
-                "spec": {
-                  "template": {
-                    "metadata": {
-                      "name.$": "States.Format('remoter-client-6173646667-{}', $.index)",
-                      "labels": {
-                        "type": "pipeline"
-                      }
-                    },
-                    "spec": {
-                      "containers": [
-                        {
-                          "name": "remoter-client",
-                          "image": "mock-remoter-client-image",
-                          "args": [
-                            "{\\"experimentId\\":\\"mock-experiment-id\\",\\"taskName\\":\\"classifier\\",\\"config\\":{},\\"server\\":\\"remoter-server-mock-experiment-id.pipeline-test-namespace.svc.cluster.local\\"}"
                           ],
                           "env": [
                             {


### PR DESCRIPTION
# Background
#### Link to issue 
https://biomage.atlassian.net/browse/BIOMAGE-694

#### Link to staging deployment URL 
https://ui-martinfosco-ui172-api77.scp-staging.biomage.net/

#### Links to any Pull Requests related to this
https://github.com/biomage-ltd/ui/pull/172

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [x] Tested locally with Inframock
- [x] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
