### PR TITLE
Fix plot styling overwriting plot data

### DIFF
--- a/src/api/route-services/pipeline-response.js
+++ b/src/api/route-services/pipeline-response.js
@@ -38,7 +38,7 @@ const pipelineResponse = async (io, message) => {
 
   if (output.plotDataKeys) {
     const plotConfigUploads = Object.entries(output.plotDataKeys).map(([plotUuid, objKey]) => (
-      plotsTableService.updatePlotData(
+      plotsTableService.updatePlotDataKey(
         experimentId,
         plotUuid,
         objKey,

--- a/src/api/route-services/plots-tables.js
+++ b/src/api/route-services/plots-tables.js
@@ -110,7 +110,6 @@ class PlotsTablesService {
 
     if (plotDataKey) {
       const { plotData } = await this.readFromS3(plotDataKey);
-
       configToReturn.plotData = plotData || {};
     }
 

--- a/src/api/route-services/plots-tables.js
+++ b/src/api/route-services/plots-tables.js
@@ -24,12 +24,12 @@ class PlotsTablesService {
     };
 
     const dynamodb = createDynamoDbInstance();
-    await dynamodb.putItem(params).promise();
+    await dynamodb.updateItem(params).promise();
 
     return tableData;
   }
 
-  async updatePlotData(experimentId, plotUuid, plotDataKey) {
+  async updatePlotDataKey(experimentId, plotUuid, plotDataKey) {
     const marshalledData = convertToDynamoDbRecord({
       ':plotDataKey': plotDataKey,
       ':config': {},

--- a/src/api/route-services/plots-tables.js
+++ b/src/api/route-services/plots-tables.js
@@ -16,11 +16,19 @@ class PlotsTablesService {
       lastUpdated: new Date().toDateString(),
     };
 
-    const plotConfig = convertToDynamoDbRecord(tableData);
+    const marshalledData = convertToDynamoDbRecord({
+      ':config': data.config,
+      ':lastUpdated': new Date().toDateString(),
+    });
 
     const params = {
       TableName: this.tableName,
-      Item: plotConfig,
+      Key: {
+        experimentId: { S: experimentId }, plotUuid: { S: plotUuid },
+      },
+      UpdateExpression: 'SET config = :config, lastUpdated = :lastUpdated',
+      ExpressionAttributeValues: marshalledData,
+      ReturnValues: 'UPDATED_NEW',
     };
 
     const dynamodb = createDynamoDbInstance();

--- a/src/api/routes/plots-tables.js
+++ b/src/api/routes/plots-tables.js
@@ -12,7 +12,6 @@ module.exports = {
   },
   'plots-tables#read': (req, res, next) => {
     const { experimentId, plotUuid } = req.params;
-
     plotsTablesService.read(experimentId, plotUuid)
       .then((response) => res.json(response))
       .catch((e) => {

--- a/tests/api/route-services/__snapshots__/plots-tables.test.js.snap
+++ b/tests/api/route-services/__snapshots__/plots-tables.test.js.snap
@@ -5,34 +5,22 @@ exports[`Test Plot Config Service create operation, puts data in database 1`] = 
   "calls": Array [
     Array [
       Object {
-        "Item": Object {
-          "baz": Object {
-            "L": Array [
-              Object {
-                "N": "1",
-              },
-              Object {
-                "N": "2",
-              },
-              Object {
-                "N": "3",
-              },
-            ],
+        "ExpressionAttributeValues": Object {
+          ":lastUpdated": Object {
+            "S": "Wed Jan 01 2020",
           },
+        },
+        "Key": Object {
           "experimentId": Object {
             "S": "1",
-          },
-          "foo": Object {
-            "S": "bar",
-          },
-          "lastUpdated": Object {
-            "S": "Wed Jan 01 2020",
           },
           "plotUuid": Object {
             "S": "plot1",
           },
         },
+        "ReturnValues": "UPDATED_NEW",
         "TableName": "plots-tables-test",
+        "UpdateExpression": "SET config = :config, lastUpdated = :lastUpdated",
       },
     ],
   ],

--- a/tests/api/route-services/plots-tables.test.js
+++ b/tests/api/route-services/plots-tables.test.js
@@ -25,15 +25,15 @@ describe('Test Plot Config Service', () => {
       foo: 'bar', baz: [1, 2, 3],
     };
 
-    const putItem = jest.fn();
+    const updateItem = jest.fn();
     AWSMock.setSDKInstance(AWS);
-    AWSMock.mock('DynamoDB', 'putItem', (params, callback) => {
-      putItem(params);
+    AWSMock.mock('DynamoDB', 'updateItem', (params, callback) => {
+      updateItem(params);
       callback(null, data);
     });
 
     await new PlotsTablesService().create(EXPERIMENT_ID, PLOT_UUID, data);
-    expect(putItem).toMatchSnapshot();
+    expect(updateItem).toMatchSnapshot();
   });
 
   it('delete operation, delete data from database', async () => {


### PR DESCRIPTION
# Background
#### Link to issue 

#### Link to staging deployment URL 
https://ui-martinfosco-ui173-api78-pi.scp-staging.biomage.net/

#### Links to any Pull Requests related to this
https://github.com/biomage-ltd/ui/pull/173

#### Anything else the reviewers should know about the changes here
The plot styling config, when updated in the ui, overwrites plotDataKey because it uses a `putItem` dynamodb operation.

It should instead use an `updateItem` which will keep plotDataKey intact.

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [x] Tested locally with Inframock
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
