### PR TITLE
Make API use AWS Step Function activities

### DIFF
--- a/src/api/general-services/pipeline-manage/constructors/create-new-job-if-not-exist.js
+++ b/src/api/general-services/pipeline-manage/constructors/create-new-job-if-not-exist.js
@@ -53,6 +53,7 @@ const createNewJobIfNotExist = (context, step) => {
           },
           labels: {
             sandboxId: config.sandboxId,
+            type: 'pipeline',
           },
         },
         spec: {

--- a/src/api/general-services/pipeline-manage/constructors/create-new-job-if-not-exist.js
+++ b/src/api/general-services/pipeline-manage/constructors/create-new-job-if-not-exist.js
@@ -64,7 +64,7 @@ const createNewJobIfNotExist = (context, step) => {
           },
           values: {
             experimentId,
-            image: pipelineArtifacts['remoter-server'],
+            image: pipelineArtifacts['qc-runner'],
             namespace: config.pipelineNamespace,
             sandboxId: config.sandboxId,
             awsAccountId: accountId,

--- a/src/api/general-services/pipeline-manage/constructors/create-new-step.js
+++ b/src/api/general-services/pipeline-manage/constructors/create-new-step.js
@@ -1,9 +1,8 @@
-const crypto = require('crypto');
 const config = require('../../../../config');
 
 const createNewStep = (context, step, args) => {
   const {
-    processingConfig, clusterInfo, experimentId, pipelineArtifacts, accountId,
+    processingConfig, experimentId, activityArn,
   } = context;
 
   const { taskName, perSample } = args;
@@ -12,117 +11,25 @@ const createNewStep = (context, step, args) => {
   ) ? 'host.docker.internal'
     : `remoter-server-${experimentId}.${config.pipelineNamespace}.svc.cluster.local`;
 
-  const task = JSON.stringify({
+  const task = {
     experimentId,
     taskName,
     config: processingConfig[taskName] || {},
     server: remoterServer,
-  });
-
-  const stepHash = crypto.randomBytes(5).toString('hex');
-
-  if (config.clusterEnv === 'development') {
-    return {
-      ...step,
-      Type: 'Task',
-      Resource: 'arn:aws:states:::lambda:invoke',
-      // TODO: fix this, add some of old output
-      // see https://docs.aws.amazon.com/step-functions/latest/dg/input-output-resultpath.html
-      ResultPath: null,
-      Parameters: {
-        FunctionName: `arn:aws:lambda:eu-west-1:${accountId}:function:local-container-launcher`,
-        Payload: {
-          image: 'biomage-remoter-client',
-          name: 'pipeline-remoter-client',
-          task,
-          ...perSample && { 'sampleUuid.$': '$.sampleUuid' },
-          detached: false,
-        },
-      },
-      Catch: [
-        {
-          ErrorEquals: ['States.ALL'],
-          ResultPath: '$.error-info',
-          Next: step.XNextOnCatch || step.Next,
-        },
-      ],
-    };
-  }
-
+  };
 
   return {
     ...step,
     Type: 'Task',
-    Comment: 'Attempts to create a Kubernetes Job for the pipeline server. Will swallow a 409 (already exists) error.',
-    Resource: 'arn:aws:states:::eks:runJob.sync',
-    // TODO: fix this, add some of old output
-    // see https://docs.aws.amazon.com/step-functions/latest/dg/input-output-resultpath.html
+    Resource: activityArn,
     ResultPath: null,
+    TimeoutSeconds: 300,
+    HeartbeatSeconds: 60,
     Parameters: {
-      ClusterName: clusterInfo.name,
-      CertificateAuthority: clusterInfo.certAuthority,
-      Endpoint: clusterInfo.endpoint,
-      Namespace: config.pipelineNamespace,
-      LogOptions: {
-        RetrieveLogs: true,
-      },
-      Job: {
-        apiVersion: 'batch/v1',
-        kind: 'Job',
-        metadata: {
-          ...perSample && { 'name.$': `States.Format('remoter-client-${stepHash}-{}', $.index)` },
-          ...!perSample && { name: `remoter-client-${stepHash}` },
-          labels: {
-            sandboxId: config.sandboxId,
-            experimentId,
-            taskName,
-            type: 'pipeline',
-          },
-        },
-        spec: {
-          template: {
-            metadata: {
-              ...perSample && { 'name.$': `States.Format('remoter-client-${stepHash}-{}', $.index)` },
-              ...!perSample && { name: `remoter-client-${stepHash}` },
-              labels: {
-                sandboxId: config.sandboxId,
-                type: 'pipeline',
-              },
-            },
-            spec: {
-              containers: [
-                {
-                  name: 'remoter-client',
-                  image: pipelineArtifacts['remoter-client'],
-                  args: [
-                    task,
-                  ],
-                  env: [
-                    ...perSample ? [{ name: 'SAMPLE_ID', 'value.$': '$.sampleUuid' }] : [],
-                  ],
-                },
-              ],
-              restartPolicy: 'Never',
-            },
-          },
-        },
-      },
+      ...task,
+      ...perSample ? { 'sampleUuid.$': '$.sampleUuid' } : { sampleUuid: '' },
     },
-    Retry: [
-      {
-        ErrorEquals: ['EKS.409'],
-        IntervalSeconds: 1,
-        BackoffRate: 2.0,
-        MaxAttempts: 2,
-      },
-    ],
-    Catch: [
-      {
-        ErrorEquals: ['EKS.409'],
-        ResultPath: '$.error-info',
-        Next: step.XNextOnCatch || step.Next,
-      },
-    ],
+    ...!step.End && { Next: step.XNextOnCatch || step.Next },
   };
 };
 

--- a/src/api/general-services/pipeline-manage/constructors/create-new-step.js
+++ b/src/api/general-services/pipeline-manage/constructors/create-new-step.js
@@ -24,7 +24,6 @@ const createNewStep = (context, step, args) => {
     Resource: activityArn,
     ResultPath: null,
     TimeoutSeconds: 300,
-    HeartbeatSeconds: 60,
     Parameters: {
       ...task,
       ...perSample ? { 'sampleUuid.$': '$.sampleUuid' } : { sampleUuid: '' },

--- a/src/api/general-services/pipeline-manage/index.js
+++ b/src/api/general-services/pipeline-manage/index.js
@@ -29,8 +29,7 @@ const getPipelineArtifacts = async () => {
 
   return {
     chartRef: jq.json(manifest, '..|objects| select(.metadata != null) | select( .metadata.name | contains("pipeline")) | .spec.chart.ref//empty'),
-    'remoter-server': jq.json(manifest, '..|objects|.["remoter-server"].image//empty'),
-    'remoter-client': jq.json(manifest, '..|objects|.["remoter-client"].image//empty'),
+    'qc-runner': jq.json(manifest, '..|objects|.["qc-runner"].image//empty'),
   };
 };
 

--- a/src/api/general-services/pipeline-manage/index.js
+++ b/src/api/general-services/pipeline-manage/index.js
@@ -29,7 +29,7 @@ const getPipelineArtifacts = async () => {
 
   return {
     chartRef: jq.json(manifest, '..|objects| select(.metadata != null) | select( .metadata.name | contains("pipeline")) | .spec.chart.ref//empty'),
-    'qc-runner': jq.json(manifest, '..|objects|.["remoter-server"].image//empty'),
+    'qc-runner': jq.json(manifest, '..|objects|.["qc-runner"].image//empty'),
   };
 };
 

--- a/src/api/general-services/pipeline-manage/index.js
+++ b/src/api/general-services/pipeline-manage/index.js
@@ -29,7 +29,7 @@ const getPipelineArtifacts = async () => {
 
   return {
     chartRef: jq.json(manifest, '..|objects| select(.metadata != null) | select( .metadata.name | contains("pipeline")) | .spec.chart.ref//empty'),
-    'qc-runner': jq.json(manifest, '..|objects|.["qc-runner"].image//empty'),
+    'qc-runner': jq.json(manifest, '..|objects|.["remoter-server"].image//empty'),
   };
 };
 

--- a/src/api/general-services/pipeline-manage/index.js
+++ b/src/api/general-services/pipeline-manage/index.js
@@ -256,7 +256,7 @@ const createPipeline = async (experimentId, processingConfigUpdates) => {
   // appropriate.
   // eslint-disable-next-line consistent-return
   const mergedProcessingConfig = _.cloneDeepWith(processingConfig, (o) => {
-    if (_.isObject(o) && !o.dataIntegration && o.enabled) {
+    if (_.isObject(o) && !o.dataIntegration && typeof o.enabled === 'boolean') {
       // Find which samples have sample-specific configurations.
       const sampleConfigs = _.intersection(Object.keys(o), samples.ids);
 

--- a/src/api/general-services/pipeline-manage/index.js
+++ b/src/api/general-services/pipeline-manage/index.js
@@ -313,13 +313,11 @@ const createPipeline = async (experimentId, processingConfigUpdates) => {
     }
   });
 
-  const arnRandomString = Math.random().toString(36).slice(2);
-
   const context = {
     experimentId,
     accountId,
     roleArn,
-    activityArn: `arn:aws:states:${config.awsRegion}:${accountId}:activity:biomage-qc-${config.clusterEnv}-${experimentId}-${arnRandomString}`,
+    activityArn: `arn:aws:states:${config.awsRegion}:${accountId}:activity:biomage-qc-${config.clusterEnv}-${experimentId}`,
     pipelineArtifacts: await getPipelineArtifacts(),
     clusterInfo: await getClusterInfo(),
     processingConfig: mergedProcessingConfig,

--- a/src/api/general-services/pipeline-manage/index.js
+++ b/src/api/general-services/pipeline-manage/index.js
@@ -138,13 +138,13 @@ const buildStateMachineDefinition = (context) => {
       },
       LaunchNewPipelineWorker: {
         XStepType: 'create-new-job-if-not-exist',
-        Next: 'Filters',
+        Next: 'ClassifierFilterMap',
         ResultPath: null,
       },
-      Filters: {
+      ClassifierFilterMap: {
         Type: 'Map',
-        Next: 'DataIntegration',
-        MaxConcurrency: 1,
+        Next: 'CellSizeDistributionFilterMap',
+        ResultPath: null,
         ItemsPath: '$.samples',
         Iterator: {
           StartAt: 'ClassifierFilter',
@@ -155,42 +155,82 @@ const buildStateMachineDefinition = (context) => {
                 perSample: true,
                 taskName: 'classifier',
               },
-              Next: 'CellSizeDistributionFilter',
+              End: true,
             },
+          },
+        },
+      },
+      CellSizeDistributionFilterMap: {
+        Type: 'Map',
+        Next: 'MitochondrialContentFilterMap',
+        ResultPath: null,
+        ItemsPath: '$.samples',
+        Iterator: {
+          StartAt: 'CellSizeDistributionFilter',
+          States: {
             CellSizeDistributionFilter: {
               XStepType: 'create-new-step',
               XConstructorArgs: {
                 perSample: true,
                 taskName: 'cellSizeDistribution',
               },
-              Next: 'MitochondrialContentFilter',
+              End: true,
             },
+          },
+        },
+      },
+      MitochondrialContentFilterMap: {
+        Type: 'Map',
+        Next: 'NumGenesVsNumUmisFilterMap',
+        ResultPath: null,
+        ItemsPath: '$.samples',
+        Iterator: {
+          StartAt: 'MitochondrialContentFilter',
+          States: {
             MitochondrialContentFilter: {
               XStepType: 'create-new-step',
               XConstructorArgs: {
                 perSample: true,
                 taskName: 'mitochondrialContent',
               },
-              Next: 'NumGenesVsNumUmisFilter',
+              End: true,
             },
+          },
+        },
+      },
+      NumGenesVsNumUmisFilterMap: {
+        Type: 'Map',
+        Next: 'DoubletScoresFilterMap',
+        ResultPath: null,
+        ItemsPath: '$.samples',
+        Iterator: {
+          StartAt: 'NumGenesVsNumUmisFilter',
+          States: {
             NumGenesVsNumUmisFilter: {
               XStepType: 'create-new-step',
               XConstructorArgs: {
                 perSample: true,
                 taskName: 'numGenesVsNumUmis',
               },
-              Next: 'DoubletScoresFilter',
+              End: true,
             },
+          },
+        },
+      },
+      DoubletScoresFilterMap: {
+        Type: 'Map',
+        Next: 'DataIntegration',
+        ResultPath: null,
+        ItemsPath: '$.samples',
+        Iterator: {
+          StartAt: 'DoubletScoresFilter',
+          States: {
             DoubletScoresFilter: {
               XStepType: 'create-new-step',
               XConstructorArgs: {
                 perSample: true,
                 taskName: 'doubletScores',
               },
-              Next: 'EndOfMap',
-            },
-            EndOfMap: {
-              Type: 'Pass',
               End: true,
             },
           },

--- a/src/api/general-services/pipeline-manage/index.js
+++ b/src/api/general-services/pipeline-manage/index.js
@@ -313,11 +313,13 @@ const createPipeline = async (experimentId, processingConfigUpdates) => {
     }
   });
 
+  const arnRandomString = Math.random().toString(36).slice(2);
+
   const context = {
     experimentId,
     accountId,
     roleArn,
-    activityArn: `arn:aws:states:${config.awsRegion}:${accountId}:activity:biomage-qc-${config.clusterEnv}-${experimentId}`,
+    activityArn: `arn:aws:states:${config.awsRegion}:${accountId}:activity:biomage-qc-${config.clusterEnv}-${experimentId}-${arnRandomString}`,
     pipelineArtifacts: await getPipelineArtifacts(),
     clusterInfo: await getClusterInfo(),
     processingConfig: mergedProcessingConfig,

--- a/src/api/general-services/pipeline-status.js
+++ b/src/api/general-services/pipeline-status.js
@@ -57,7 +57,7 @@ const getStepsFromExecutionHistory = (events) => {
       } else {
         this.visited.push(event.id);
         this.updateCurrentState(event);
-        if (event.type === 'ActivitySucceeded') {
+        if (event.type === 'TaskSucceeded' || event.type === 'ActivitySucceeded') {
           this.completedTasks.push(this.currentState);
         } else if (event.type === 'MapStateStarted') {
           this.branchCount = event.mapStateStartedEventDetails.length;

--- a/src/api/general-services/pipeline-status.js
+++ b/src/api/general-services/pipeline-status.js
@@ -57,7 +57,7 @@ const getStepsFromExecutionHistory = (events) => {
       } else {
         this.visited.push(event.id);
         this.updateCurrentState(event);
-        if (event.type === 'TaskSucceeded') {
+        if (event.type === 'ActivitySucceeded') {
           this.completedTasks.push(this.currentState);
         } else if (event.type === 'MapStateStarted') {
           this.branchCount = event.mapStateStartedEventDetails.length;

--- a/src/api/general-services/work-submit/create-worker-k8s.js
+++ b/src/api/general-services/work-submit/create-worker-k8s.js
@@ -70,11 +70,19 @@ const createWorkerResources = async (service) => {
 
     logger.log(`Worker instance ${release.name} successfully created.`);
   } catch (error) {
-    if (!error.stderr || !error.stderr.includes('release: already exists')) {
+    if (!error.stderr) {
       throw error;
     }
 
-    logger.log('Worker instance is being created by another process, skipping...');
+    if (
+      error.stderr.includes('release: already exists')
+      || error.stderr.includes('another operation (install/upgrade/rollback) is in progress')
+    ) {
+      logger.log('Worker instance is being created by another process, skipping...');
+      return;
+    }
+
+    throw error;
   }
 };
 

--- a/src/config/default-config.js
+++ b/src/config/default-config.js
@@ -86,6 +86,8 @@ if (config.clusterEnv === 'development') {
     s3ForcePathStyle: true,
   });
 
+  config.pipelineInstanceConfigUrl = 'https://raw.githubusercontent.com/biomage-ltd/iac/master/releases/staging/use-activities.yaml';
+
   config.corsOriginUrl = 'http://localhost:5000';
 }
 

--- a/src/config/test-config.js
+++ b/src/config/test-config.js
@@ -15,7 +15,7 @@ module.exports = {
   workerNamespace: 'worker-test-namespace',
   pipelineNamespace: 'pipeline-test-namespace',
   workerInstanceConfigUrl: 'https://raw.githubusercontent.com/biomage-ltd/iac/master/releases/production/worker.yaml',
-  pipelineInstanceConfigUrl: 'https://raw.githubusercontent.com/biomage-ltd/iac/master/releases/production/pipeline.yaml',
+  pipelineInstanceConfigUrl: 'https://raw.githubusercontent.com/biomage-ltd/iac/master/releases/staging/use-activities.yaml',
   api: {
     prefix: '/',
   },

--- a/src/loaders/express.js
+++ b/src/loaders/express.js
@@ -63,8 +63,6 @@ module.exports = async (app) => {
     operationHandlers: path.join(__dirname, '..', 'api'),
   }));
 
-  app.use(AWSXRay.express.closeSegment());
-
   // Custom error handler.
   // eslint-disable-next-line no-unused-vars
   app.use((err, req, res, next) => {
@@ -79,6 +77,8 @@ module.exports = async (app) => {
 
     next(err);
   });
+
+  app.use(AWSXRay.express.closeSegment());
 
 
   // eslint-disable-next-line global-require

--- a/tests/api/general-services/__snapshots__/pipeline-manage.test.js.snap
+++ b/tests/api/general-services/__snapshots__/pipeline-manage.test.js.snap
@@ -71,6 +71,56 @@ Array [
       "Comment": "Pipeline for clusterEnv 'test'",
       "StartAt": "DeleteCompletedPipelineWorker",
       "States": Object {
+        "CellSizeDistributionFilterMap": Object {
+          "ItemsPath": "$.samples",
+          "Iterator": Object {
+            "StartAt": "CellSizeDistributionFilter",
+            "States": Object {
+              "CellSizeDistributionFilter": Object {
+                "End": true,
+                "Parameters": Object {
+                  "config": Object {},
+                  "experimentId": "testExperimentId",
+                  "sampleUuid.$": "$.sampleUuid",
+                  "server": "remoter-server-testExperimentId.pipeline-test-namespace.svc.cluster.local",
+                  "taskName": "cellSizeDistribution",
+                },
+                "Resource": "arn:aws:states:eu-west-1:test-account-id:activity:biomage-qc-test-testExperimentId",
+                "ResultPath": null,
+                "TimeoutSeconds": 300,
+                "Type": "Task",
+              },
+            },
+          },
+          "Next": "MitochondrialContentFilterMap",
+          "ResultPath": null,
+          "Type": "Map",
+        },
+        "ClassifierFilterMap": Object {
+          "ItemsPath": "$.samples",
+          "Iterator": Object {
+            "StartAt": "ClassifierFilter",
+            "States": Object {
+              "ClassifierFilter": Object {
+                "End": true,
+                "Parameters": Object {
+                  "config": Object {},
+                  "experimentId": "testExperimentId",
+                  "sampleUuid.$": "$.sampleUuid",
+                  "server": "remoter-server-testExperimentId.pipeline-test-namespace.svc.cluster.local",
+                  "taskName": "classifier",
+                },
+                "Resource": "arn:aws:states:eu-west-1:test-account-id:activity:biomage-qc-test-testExperimentId",
+                "ResultPath": null,
+                "TimeoutSeconds": 300,
+                "Type": "Task",
+              },
+            },
+          },
+          "Next": "CellSizeDistributionFilterMap",
+          "ResultPath": null,
+          "Type": "Map",
+        },
         "ConfigureEmbedding": Object {
           "Next": "EndOfPipeline",
           "Parameters": Object {
@@ -118,45 +168,13 @@ Array [
           "ResultPath": null,
           "Type": "Task",
         },
-        "EndOfPipeline": Object {
-          "End": true,
-          "Type": "Pass",
-        },
-        "Filters": Object {
+        "DoubletScoresFilterMap": Object {
           "ItemsPath": "$.samples",
           "Iterator": Object {
-            "StartAt": "ClassifierFilter",
+            "StartAt": "DoubletScoresFilter",
             "States": Object {
-              "CellSizeDistributionFilter": Object {
-                "Next": "MitochondrialContentFilter",
-                "Parameters": Object {
-                  "config": Object {},
-                  "experimentId": "testExperimentId",
-                  "sampleUuid.$": "$.sampleUuid",
-                  "server": "remoter-server-testExperimentId.pipeline-test-namespace.svc.cluster.local",
-                  "taskName": "cellSizeDistribution",
-                },
-                "Resource": "arn:aws:states:eu-west-1:test-account-id:activity:biomage-qc-test-testExperimentId",
-                "ResultPath": null,
-                "TimeoutSeconds": 300,
-                "Type": "Task",
-              },
-              "ClassifierFilter": Object {
-                "Next": "CellSizeDistributionFilter",
-                "Parameters": Object {
-                  "config": Object {},
-                  "experimentId": "testExperimentId",
-                  "sampleUuid.$": "$.sampleUuid",
-                  "server": "remoter-server-testExperimentId.pipeline-test-namespace.svc.cluster.local",
-                  "taskName": "classifier",
-                },
-                "Resource": "arn:aws:states:eu-west-1:test-account-id:activity:biomage-qc-test-testExperimentId",
-                "ResultPath": null,
-                "TimeoutSeconds": 300,
-                "Type": "Task",
-              },
               "DoubletScoresFilter": Object {
-                "Next": "EndOfMap",
+                "End": true,
                 "Parameters": Object {
                   "config": Object {
                     "filterSettings": Object {
@@ -183,43 +201,15 @@ Array [
                 "TimeoutSeconds": 300,
                 "Type": "Task",
               },
-              "EndOfMap": Object {
-                "End": true,
-                "Type": "Pass",
-              },
-              "MitochondrialContentFilter": Object {
-                "Next": "NumGenesVsNumUmisFilter",
-                "Parameters": Object {
-                  "config": Object {},
-                  "experimentId": "testExperimentId",
-                  "sampleUuid.$": "$.sampleUuid",
-                  "server": "remoter-server-testExperimentId.pipeline-test-namespace.svc.cluster.local",
-                  "taskName": "mitochondrialContent",
-                },
-                "Resource": "arn:aws:states:eu-west-1:test-account-id:activity:biomage-qc-test-testExperimentId",
-                "ResultPath": null,
-                "TimeoutSeconds": 300,
-                "Type": "Task",
-              },
-              "NumGenesVsNumUmisFilter": Object {
-                "Next": "DoubletScoresFilter",
-                "Parameters": Object {
-                  "config": Object {},
-                  "experimentId": "testExperimentId",
-                  "sampleUuid.$": "$.sampleUuid",
-                  "server": "remoter-server-testExperimentId.pipeline-test-namespace.svc.cluster.local",
-                  "taskName": "numGenesVsNumUmis",
-                },
-                "Resource": "arn:aws:states:eu-west-1:test-account-id:activity:biomage-qc-test-testExperimentId",
-                "ResultPath": null,
-                "TimeoutSeconds": 300,
-                "Type": "Task",
-              },
             },
           },
-          "MaxConcurrency": 1,
           "Next": "DataIntegration",
+          "ResultPath": null,
           "Type": "Map",
+        },
+        "EndOfPipeline": Object {
+          "End": true,
+          "Type": "Pass",
         },
         "LaunchNewPipelineWorker": Object {
           "Catch": Array [
@@ -227,12 +217,12 @@ Array [
               "ErrorEquals": Array [
                 "EKS.409",
               ],
-              "Next": "Filters",
+              "Next": "ClassifierFilterMap",
               "ResultPath": "$.error-info",
             },
           ],
           "Comment": "Attempts to create a Kubernetes Job+Service for the pipeline runner. Will swallow a 409 (already exists) error.",
-          "Next": "Filters",
+          "Next": "ClassifierFilterMap",
           "Parameters": Object {
             "CertificateAuthority": "AAAAAAAAAAA",
             "ClusterName": "biomage-test",
@@ -284,6 +274,56 @@ Array [
             },
           ],
           "Type": "Task",
+        },
+        "MitochondrialContentFilterMap": Object {
+          "ItemsPath": "$.samples",
+          "Iterator": Object {
+            "StartAt": "MitochondrialContentFilter",
+            "States": Object {
+              "MitochondrialContentFilter": Object {
+                "End": true,
+                "Parameters": Object {
+                  "config": Object {},
+                  "experimentId": "testExperimentId",
+                  "sampleUuid.$": "$.sampleUuid",
+                  "server": "remoter-server-testExperimentId.pipeline-test-namespace.svc.cluster.local",
+                  "taskName": "mitochondrialContent",
+                },
+                "Resource": "arn:aws:states:eu-west-1:test-account-id:activity:biomage-qc-test-testExperimentId",
+                "ResultPath": null,
+                "TimeoutSeconds": 300,
+                "Type": "Task",
+              },
+            },
+          },
+          "Next": "NumGenesVsNumUmisFilterMap",
+          "ResultPath": null,
+          "Type": "Map",
+        },
+        "NumGenesVsNumUmisFilterMap": Object {
+          "ItemsPath": "$.samples",
+          "Iterator": Object {
+            "StartAt": "NumGenesVsNumUmisFilter",
+            "States": Object {
+              "NumGenesVsNumUmisFilter": Object {
+                "End": true,
+                "Parameters": Object {
+                  "config": Object {},
+                  "experimentId": "testExperimentId",
+                  "sampleUuid.$": "$.sampleUuid",
+                  "server": "remoter-server-testExperimentId.pipeline-test-namespace.svc.cluster.local",
+                  "taskName": "numGenesVsNumUmis",
+                },
+                "Resource": "arn:aws:states:eu-west-1:test-account-id:activity:biomage-qc-test-testExperimentId",
+                "ResultPath": null,
+                "TimeoutSeconds": 300,
+                "Type": "Task",
+              },
+            },
+          },
+          "Next": "DoubletScoresFilterMap",
+          "ResultPath": null,
+          "Type": "Map",
         },
       },
     },

--- a/tests/api/general-services/__snapshots__/pipeline-manage.test.js.snap
+++ b/tests/api/general-services/__snapshots__/pipeline-manage.test.js.snap
@@ -246,7 +246,9 @@ Array [
                 "annotations": Object {
                   "fluxcd.io/automated": "true",
                 },
-                "labels": Object {},
+                "labels": Object {
+                  "type": "pipeline",
+                },
                 "name": "pipeline-testExperimentId",
                 "namespace": "pipeline-test-namespace",
               },

--- a/tests/api/general-services/__snapshots__/pipeline-manage.test.js.snap
+++ b/tests/api/general-services/__snapshots__/pipeline-manage.test.js.snap
@@ -72,143 +72,33 @@ Array [
       "StartAt": "DeleteCompletedPipelineWorker",
       "States": Object {
         "ConfigureEmbedding": Object {
-          "Catch": Array [
-            Object {
-              "ErrorEquals": Array [
-                "EKS.409",
-              ],
-              "Next": "EndOfPipeline",
-              "ResultPath": "$.error-info",
-            },
-          ],
-          "Comment": "Attempts to create a Kubernetes Job for the pipeline server. Will swallow a 409 (already exists) error.",
-          "End": true,
+          "HeartbeatSeconds": 60,
+          "Next": "EndOfPipeline",
           "Parameters": Object {
-            "CertificateAuthority": "AAAAAAAAAAA",
-            "ClusterName": "biomage-test",
-            "Endpoint": "https://test-endpoint.me/fgh",
-            "Job": Object {
-              "apiVersion": "batch/v1",
-              "kind": "Job",
-              "metadata": Object {
-                "labels": Object {
-                  "experimentId": "testExperimentId",
-                  "taskName": "configureEmbedding",
-                  "type": "pipeline",
-                },
-                "name": "remoter-client-6173646667",
-              },
-              "spec": Object {
-                "template": Object {
-                  "metadata": Object {
-                    "labels": Object {
-                      "type": "pipeline",
-                    },
-                    "name": "remoter-client-6173646667",
-                  },
-                  "spec": Object {
-                    "containers": Array [
-                      Object {
-                        "args": Array [
-                          "{\\"experimentId\\":\\"testExperimentId\\",\\"taskName\\":\\"configureEmbedding\\",\\"config\\":{},\\"server\\":\\"remoter-server-testExperimentId.pipeline-test-namespace.svc.cluster.local\\"}",
-                        ],
-                        "env": Array [],
-                        "image": "MOCK_IMAGE_PATH",
-                        "name": "remoter-client",
-                      },
-                    ],
-                    "restartPolicy": "Never",
-                  },
-                },
-              },
-            },
-            "LogOptions": Object {
-              "RetrieveLogs": true,
-            },
-            "Namespace": "pipeline-test-namespace",
+            "config": Object {},
+            "experimentId": "testExperimentId",
+            "sampleUuid": "",
+            "server": "remoter-server-testExperimentId.pipeline-test-namespace.svc.cluster.local",
+            "taskName": "configureEmbedding",
           },
-          "Resource": "arn:aws:states:::eks:runJob.sync",
+          "Resource": "arn:aws:states:eu-west-1:test-account-id:activity:biomage-qc-test-testExperimentId",
           "ResultPath": null,
-          "Retry": Array [
-            Object {
-              "BackoffRate": 2,
-              "ErrorEquals": Array [
-                "EKS.409",
-              ],
-              "IntervalSeconds": 1,
-              "MaxAttempts": 2,
-            },
-          ],
+          "TimeoutSeconds": 300,
           "Type": "Task",
         },
         "DataIntegration": Object {
-          "Catch": Array [
-            Object {
-              "ErrorEquals": Array [
-                "EKS.409",
-              ],
-              "Next": "ConfigureEmbedding",
-              "ResultPath": "$.error-info",
-            },
-          ],
-          "Comment": "Attempts to create a Kubernetes Job for the pipeline server. Will swallow a 409 (already exists) error.",
+          "HeartbeatSeconds": 60,
           "Next": "ConfigureEmbedding",
           "Parameters": Object {
-            "CertificateAuthority": "AAAAAAAAAAA",
-            "ClusterName": "biomage-test",
-            "Endpoint": "https://test-endpoint.me/fgh",
-            "Job": Object {
-              "apiVersion": "batch/v1",
-              "kind": "Job",
-              "metadata": Object {
-                "labels": Object {
-                  "experimentId": "testExperimentId",
-                  "taskName": "dataIntegration",
-                  "type": "pipeline",
-                },
-                "name": "remoter-client-6173646667",
-              },
-              "spec": Object {
-                "template": Object {
-                  "metadata": Object {
-                    "labels": Object {
-                      "type": "pipeline",
-                    },
-                    "name": "remoter-client-6173646667",
-                  },
-                  "spec": Object {
-                    "containers": Array [
-                      Object {
-                        "args": Array [
-                          "{\\"experimentId\\":\\"testExperimentId\\",\\"taskName\\":\\"dataIntegration\\",\\"config\\":{},\\"server\\":\\"remoter-server-testExperimentId.pipeline-test-namespace.svc.cluster.local\\"}",
-                        ],
-                        "env": Array [],
-                        "image": "MOCK_IMAGE_PATH",
-                        "name": "remoter-client",
-                      },
-                    ],
-                    "restartPolicy": "Never",
-                  },
-                },
-              },
-            },
-            "LogOptions": Object {
-              "RetrieveLogs": true,
-            },
-            "Namespace": "pipeline-test-namespace",
+            "config": Object {},
+            "experimentId": "testExperimentId",
+            "sampleUuid": "",
+            "server": "remoter-server-testExperimentId.pipeline-test-namespace.svc.cluster.local",
+            "taskName": "dataIntegration",
           },
-          "Resource": "arn:aws:states:::eks:runJob.sync",
+          "Resource": "arn:aws:states:eu-west-1:test-account-id:activity:biomage-qc-test-testExperimentId",
           "ResultPath": null,
-          "Retry": Array [
-            Object {
-              "BackoffRate": 2,
-              "ErrorEquals": Array [
-                "EKS.409",
-              ],
-              "IntervalSeconds": 1,
-              "MaxAttempts": 2,
-            },
-          ],
+          "TimeoutSeconds": 300,
           "Type": "Task",
         },
         "DeleteCompletedPipelineWorker": Object {
@@ -240,228 +130,62 @@ Array [
             "StartAt": "ClassifierFilter",
             "States": Object {
               "CellSizeDistributionFilter": Object {
-                "Catch": Array [
-                  Object {
-                    "ErrorEquals": Array [
-                      "EKS.409",
-                    ],
-                    "Next": "MitochondrialContentFilter",
-                    "ResultPath": "$.error-info",
-                  },
-                ],
-                "Comment": "Attempts to create a Kubernetes Job for the pipeline server. Will swallow a 409 (already exists) error.",
+                "HeartbeatSeconds": 60,
                 "Next": "MitochondrialContentFilter",
                 "Parameters": Object {
-                  "CertificateAuthority": "AAAAAAAAAAA",
-                  "ClusterName": "biomage-test",
-                  "Endpoint": "https://test-endpoint.me/fgh",
-                  "Job": Object {
-                    "apiVersion": "batch/v1",
-                    "kind": "Job",
-                    "metadata": Object {
-                      "labels": Object {
-                        "experimentId": "testExperimentId",
-                        "taskName": "cellSizeDistribution",
-                        "type": "pipeline",
-                      },
-                      "name.$": "States.Format('remoter-client-6173646667-{}', $.index)",
-                    },
-                    "spec": Object {
-                      "template": Object {
-                        "metadata": Object {
-                          "labels": Object {
-                            "type": "pipeline",
-                          },
-                          "name.$": "States.Format('remoter-client-6173646667-{}', $.index)",
-                        },
-                        "spec": Object {
-                          "containers": Array [
-                            Object {
-                              "args": Array [
-                                "{\\"experimentId\\":\\"testExperimentId\\",\\"taskName\\":\\"cellSizeDistribution\\",\\"config\\":{},\\"server\\":\\"remoter-server-testExperimentId.pipeline-test-namespace.svc.cluster.local\\"}",
-                              ],
-                              "env": Array [
-                                Object {
-                                  "name": "SAMPLE_ID",
-                                  "value.$": "$.sampleUuid",
-                                },
-                              ],
-                              "image": "MOCK_IMAGE_PATH",
-                              "name": "remoter-client",
-                            },
-                          ],
-                          "restartPolicy": "Never",
-                        },
-                      },
-                    },
-                  },
-                  "LogOptions": Object {
-                    "RetrieveLogs": true,
-                  },
-                  "Namespace": "pipeline-test-namespace",
+                  "config": Object {},
+                  "experimentId": "testExperimentId",
+                  "sampleUuid.$": "$.sampleUuid",
+                  "server": "remoter-server-testExperimentId.pipeline-test-namespace.svc.cluster.local",
+                  "taskName": "cellSizeDistribution",
                 },
-                "Resource": "arn:aws:states:::eks:runJob.sync",
+                "Resource": "arn:aws:states:eu-west-1:test-account-id:activity:biomage-qc-test-testExperimentId",
                 "ResultPath": null,
-                "Retry": Array [
-                  Object {
-                    "BackoffRate": 2,
-                    "ErrorEquals": Array [
-                      "EKS.409",
-                    ],
-                    "IntervalSeconds": 1,
-                    "MaxAttempts": 2,
-                  },
-                ],
+                "TimeoutSeconds": 300,
                 "Type": "Task",
               },
               "ClassifierFilter": Object {
-                "Catch": Array [
-                  Object {
-                    "ErrorEquals": Array [
-                      "EKS.409",
-                    ],
-                    "Next": "CellSizeDistributionFilter",
-                    "ResultPath": "$.error-info",
-                  },
-                ],
-                "Comment": "Attempts to create a Kubernetes Job for the pipeline server. Will swallow a 409 (already exists) error.",
+                "HeartbeatSeconds": 60,
                 "Next": "CellSizeDistributionFilter",
                 "Parameters": Object {
-                  "CertificateAuthority": "AAAAAAAAAAA",
-                  "ClusterName": "biomage-test",
-                  "Endpoint": "https://test-endpoint.me/fgh",
-                  "Job": Object {
-                    "apiVersion": "batch/v1",
-                    "kind": "Job",
-                    "metadata": Object {
-                      "labels": Object {
-                        "experimentId": "testExperimentId",
-                        "taskName": "classifier",
-                        "type": "pipeline",
-                      },
-                      "name.$": "States.Format('remoter-client-6173646667-{}', $.index)",
-                    },
-                    "spec": Object {
-                      "template": Object {
-                        "metadata": Object {
-                          "labels": Object {
-                            "type": "pipeline",
-                          },
-                          "name.$": "States.Format('remoter-client-6173646667-{}', $.index)",
-                        },
-                        "spec": Object {
-                          "containers": Array [
-                            Object {
-                              "args": Array [
-                                "{\\"experimentId\\":\\"testExperimentId\\",\\"taskName\\":\\"classifier\\",\\"config\\":{},\\"server\\":\\"remoter-server-testExperimentId.pipeline-test-namespace.svc.cluster.local\\"}",
-                              ],
-                              "env": Array [
-                                Object {
-                                  "name": "SAMPLE_ID",
-                                  "value.$": "$.sampleUuid",
-                                },
-                              ],
-                              "image": "MOCK_IMAGE_PATH",
-                              "name": "remoter-client",
-                            },
-                          ],
-                          "restartPolicy": "Never",
-                        },
-                      },
-                    },
-                  },
-                  "LogOptions": Object {
-                    "RetrieveLogs": true,
-                  },
-                  "Namespace": "pipeline-test-namespace",
+                  "config": Object {},
+                  "experimentId": "testExperimentId",
+                  "sampleUuid.$": "$.sampleUuid",
+                  "server": "remoter-server-testExperimentId.pipeline-test-namespace.svc.cluster.local",
+                  "taskName": "classifier",
                 },
-                "Resource": "arn:aws:states:::eks:runJob.sync",
+                "Resource": "arn:aws:states:eu-west-1:test-account-id:activity:biomage-qc-test-testExperimentId",
                 "ResultPath": null,
-                "Retry": Array [
-                  Object {
-                    "BackoffRate": 2,
-                    "ErrorEquals": Array [
-                      "EKS.409",
-                    ],
-                    "IntervalSeconds": 1,
-                    "MaxAttempts": 2,
-                  },
-                ],
+                "TimeoutSeconds": 300,
                 "Type": "Task",
               },
               "DoubletScoresFilter": Object {
-                "Catch": Array [
-                  Object {
-                    "ErrorEquals": Array [
-                      "EKS.409",
-                    ],
-                    "Next": "EndOfMap",
-                    "ResultPath": "$.error-info",
-                  },
-                ],
-                "Comment": "Attempts to create a Kubernetes Job for the pipeline server. Will swallow a 409 (already exists) error.",
-                "End": true,
+                "HeartbeatSeconds": 60,
+                "Next": "EndOfMap",
                 "Parameters": Object {
-                  "CertificateAuthority": "AAAAAAAAAAA",
-                  "ClusterName": "biomage-test",
-                  "Endpoint": "https://test-endpoint.me/fgh",
-                  "Job": Object {
-                    "apiVersion": "batch/v1",
-                    "kind": "Job",
-                    "metadata": Object {
-                      "labels": Object {
-                        "experimentId": "testExperimentId",
-                        "taskName": "doubletScores",
-                        "type": "pipeline",
-                      },
-                      "name.$": "States.Format('remoter-client-6173646667-{}', $.index)",
+                  "config": Object {
+                    "filterSettings": Object {
+                      "oneSetting": 1,
                     },
-                    "spec": Object {
-                      "template": Object {
-                        "metadata": Object {
-                          "labels": Object {
-                            "type": "pipeline",
-                          },
-                          "name.$": "States.Format('remoter-client-6173646667-{}', $.index)",
-                        },
-                        "spec": Object {
-                          "containers": Array [
-                            Object {
-                              "args": Array [
-                                "{\\"experimentId\\":\\"testExperimentId\\",\\"taskName\\":\\"doubletScores\\",\\"config\\":{\\"filterSettings\\":{\\"oneSetting\\":1},\\"oneSample\\":{\\"filterSettings\\":{\\"oneSetting\\":7}},\\"otherSample\\":{\\"filterSettings\\":{\\"oneSetting\\":15}}},\\"server\\":\\"remoter-server-testExperimentId.pipeline-test-namespace.svc.cluster.local\\"}",
-                              ],
-                              "env": Array [
-                                Object {
-                                  "name": "SAMPLE_ID",
-                                  "value.$": "$.sampleUuid",
-                                },
-                              ],
-                              "image": "MOCK_IMAGE_PATH",
-                              "name": "remoter-client",
-                            },
-                          ],
-                          "restartPolicy": "Never",
-                        },
+                    "oneSample": Object {
+                      "filterSettings": Object {
+                        "oneSetting": 7,
+                      },
+                    },
+                    "otherSample": Object {
+                      "filterSettings": Object {
+                        "oneSetting": 15,
                       },
                     },
                   },
-                  "LogOptions": Object {
-                    "RetrieveLogs": true,
-                  },
-                  "Namespace": "pipeline-test-namespace",
+                  "experimentId": "testExperimentId",
+                  "sampleUuid.$": "$.sampleUuid",
+                  "server": "remoter-server-testExperimentId.pipeline-test-namespace.svc.cluster.local",
+                  "taskName": "doubletScores",
                 },
-                "Resource": "arn:aws:states:::eks:runJob.sync",
+                "Resource": "arn:aws:states:eu-west-1:test-account-id:activity:biomage-qc-test-testExperimentId",
                 "ResultPath": null,
-                "Retry": Array [
-                  Object {
-                    "BackoffRate": 2,
-                    "ErrorEquals": Array [
-                      "EKS.409",
-                    ],
-                    "IntervalSeconds": 1,
-                    "MaxAttempts": 2,
-                  },
-                ],
+                "TimeoutSeconds": 300,
                 "Type": "Task",
               },
               "EndOfMap": Object {
@@ -469,153 +193,33 @@ Array [
                 "Type": "Pass",
               },
               "MitochondrialContentFilter": Object {
-                "Catch": Array [
-                  Object {
-                    "ErrorEquals": Array [
-                      "EKS.409",
-                    ],
-                    "Next": "NumGenesVsNumUmisFilter",
-                    "ResultPath": "$.error-info",
-                  },
-                ],
-                "Comment": "Attempts to create a Kubernetes Job for the pipeline server. Will swallow a 409 (already exists) error.",
+                "HeartbeatSeconds": 60,
                 "Next": "NumGenesVsNumUmisFilter",
                 "Parameters": Object {
-                  "CertificateAuthority": "AAAAAAAAAAA",
-                  "ClusterName": "biomage-test",
-                  "Endpoint": "https://test-endpoint.me/fgh",
-                  "Job": Object {
-                    "apiVersion": "batch/v1",
-                    "kind": "Job",
-                    "metadata": Object {
-                      "labels": Object {
-                        "experimentId": "testExperimentId",
-                        "taskName": "mitochondrialContent",
-                        "type": "pipeline",
-                      },
-                      "name.$": "States.Format('remoter-client-6173646667-{}', $.index)",
-                    },
-                    "spec": Object {
-                      "template": Object {
-                        "metadata": Object {
-                          "labels": Object {
-                            "type": "pipeline",
-                          },
-                          "name.$": "States.Format('remoter-client-6173646667-{}', $.index)",
-                        },
-                        "spec": Object {
-                          "containers": Array [
-                            Object {
-                              "args": Array [
-                                "{\\"experimentId\\":\\"testExperimentId\\",\\"taskName\\":\\"mitochondrialContent\\",\\"config\\":{},\\"server\\":\\"remoter-server-testExperimentId.pipeline-test-namespace.svc.cluster.local\\"}",
-                              ],
-                              "env": Array [
-                                Object {
-                                  "name": "SAMPLE_ID",
-                                  "value.$": "$.sampleUuid",
-                                },
-                              ],
-                              "image": "MOCK_IMAGE_PATH",
-                              "name": "remoter-client",
-                            },
-                          ],
-                          "restartPolicy": "Never",
-                        },
-                      },
-                    },
-                  },
-                  "LogOptions": Object {
-                    "RetrieveLogs": true,
-                  },
-                  "Namespace": "pipeline-test-namespace",
+                  "config": Object {},
+                  "experimentId": "testExperimentId",
+                  "sampleUuid.$": "$.sampleUuid",
+                  "server": "remoter-server-testExperimentId.pipeline-test-namespace.svc.cluster.local",
+                  "taskName": "mitochondrialContent",
                 },
-                "Resource": "arn:aws:states:::eks:runJob.sync",
+                "Resource": "arn:aws:states:eu-west-1:test-account-id:activity:biomage-qc-test-testExperimentId",
                 "ResultPath": null,
-                "Retry": Array [
-                  Object {
-                    "BackoffRate": 2,
-                    "ErrorEquals": Array [
-                      "EKS.409",
-                    ],
-                    "IntervalSeconds": 1,
-                    "MaxAttempts": 2,
-                  },
-                ],
+                "TimeoutSeconds": 300,
                 "Type": "Task",
               },
               "NumGenesVsNumUmisFilter": Object {
-                "Catch": Array [
-                  Object {
-                    "ErrorEquals": Array [
-                      "EKS.409",
-                    ],
-                    "Next": "DoubletScoresFilter",
-                    "ResultPath": "$.error-info",
-                  },
-                ],
-                "Comment": "Attempts to create a Kubernetes Job for the pipeline server. Will swallow a 409 (already exists) error.",
+                "HeartbeatSeconds": 60,
                 "Next": "DoubletScoresFilter",
                 "Parameters": Object {
-                  "CertificateAuthority": "AAAAAAAAAAA",
-                  "ClusterName": "biomage-test",
-                  "Endpoint": "https://test-endpoint.me/fgh",
-                  "Job": Object {
-                    "apiVersion": "batch/v1",
-                    "kind": "Job",
-                    "metadata": Object {
-                      "labels": Object {
-                        "experimentId": "testExperimentId",
-                        "taskName": "numGenesVsNumUmis",
-                        "type": "pipeline",
-                      },
-                      "name.$": "States.Format('remoter-client-6173646667-{}', $.index)",
-                    },
-                    "spec": Object {
-                      "template": Object {
-                        "metadata": Object {
-                          "labels": Object {
-                            "type": "pipeline",
-                          },
-                          "name.$": "States.Format('remoter-client-6173646667-{}', $.index)",
-                        },
-                        "spec": Object {
-                          "containers": Array [
-                            Object {
-                              "args": Array [
-                                "{\\"experimentId\\":\\"testExperimentId\\",\\"taskName\\":\\"numGenesVsNumUmis\\",\\"config\\":{},\\"server\\":\\"remoter-server-testExperimentId.pipeline-test-namespace.svc.cluster.local\\"}",
-                              ],
-                              "env": Array [
-                                Object {
-                                  "name": "SAMPLE_ID",
-                                  "value.$": "$.sampleUuid",
-                                },
-                              ],
-                              "image": "MOCK_IMAGE_PATH",
-                              "name": "remoter-client",
-                            },
-                          ],
-                          "restartPolicy": "Never",
-                        },
-                      },
-                    },
-                  },
-                  "LogOptions": Object {
-                    "RetrieveLogs": true,
-                  },
-                  "Namespace": "pipeline-test-namespace",
+                  "config": Object {},
+                  "experimentId": "testExperimentId",
+                  "sampleUuid.$": "$.sampleUuid",
+                  "server": "remoter-server-testExperimentId.pipeline-test-namespace.svc.cluster.local",
+                  "taskName": "numGenesVsNumUmis",
                 },
-                "Resource": "arn:aws:states:::eks:runJob.sync",
+                "Resource": "arn:aws:states:eu-west-1:test-account-id:activity:biomage-qc-test-testExperimentId",
                 "ResultPath": null,
-                "Retry": Array [
-                  Object {
-                    "BackoffRate": 2,
-                    "ErrorEquals": Array [
-                      "EKS.409",
-                    ],
-                    "IntervalSeconds": 1,
-                    "MaxAttempts": 2,
-                  },
-                ],
+                "TimeoutSeconds": 300,
                 "Type": "Task",
               },
             },
@@ -634,7 +238,7 @@ Array [
               "ResultPath": "$.error-info",
             },
           ],
-          "Comment": "Attempts to create a Kubernetes Job+Service for the pipeline server. Will swallow a 409 (already exists) error.",
+          "Comment": "Attempts to create a Kubernetes Job+Service for the pipeline runner. Will swallow a 409 (already exists) error.",
           "Next": "Filters",
           "Parameters": Object {
             "CertificateAuthority": "AAAAAAAAAAA",
@@ -649,20 +253,19 @@ Array [
                 "annotations": Object {
                   "fluxcd.io/automated": "true",
                 },
-                "labels": Object {
-                  "type": "pipeline",
-                },
-                "name": "remoter-server-testExperimentId",
+                "labels": Object {},
+                "name": "pipeline-testExperimentId",
                 "namespace": "pipeline-test-namespace",
               },
               "spec": Object {
                 "chart": Object {
                   "git": "git@github.com:biomage-ltd/pipeline",
-                  "path": "remoter-server/chart",
+                  "path": "qc-runner/chart",
                   "ref": "MOCK_REF_PATH",
                 },
-                "releaseName": "remoter-server-testExperimentId",
+                "releaseName": "pipeline-testExperimentId",
                 "values": Object {
+                  "activityArn": "arn:aws:states:eu-west-1:test-account-id:activity:biomage-qc-test-testExperimentId",
                   "awsAccountId": "test-account-id",
                   "awsRegion": "eu-west-1",
                   "clusterEnv": "test",

--- a/tests/api/general-services/__snapshots__/pipeline-manage.test.js.snap
+++ b/tests/api/general-services/__snapshots__/pipeline-manage.test.js.snap
@@ -72,7 +72,6 @@ Array [
       "StartAt": "DeleteCompletedPipelineWorker",
       "States": Object {
         "ConfigureEmbedding": Object {
-          "HeartbeatSeconds": 60,
           "Next": "EndOfPipeline",
           "Parameters": Object {
             "config": Object {},
@@ -87,7 +86,6 @@ Array [
           "Type": "Task",
         },
         "DataIntegration": Object {
-          "HeartbeatSeconds": 60,
           "Next": "ConfigureEmbedding",
           "Parameters": Object {
             "config": Object {},
@@ -130,7 +128,6 @@ Array [
             "StartAt": "ClassifierFilter",
             "States": Object {
               "CellSizeDistributionFilter": Object {
-                "HeartbeatSeconds": 60,
                 "Next": "MitochondrialContentFilter",
                 "Parameters": Object {
                   "config": Object {},
@@ -145,7 +142,6 @@ Array [
                 "Type": "Task",
               },
               "ClassifierFilter": Object {
-                "HeartbeatSeconds": 60,
                 "Next": "CellSizeDistributionFilter",
                 "Parameters": Object {
                   "config": Object {},
@@ -160,7 +156,6 @@ Array [
                 "Type": "Task",
               },
               "DoubletScoresFilter": Object {
-                "HeartbeatSeconds": 60,
                 "Next": "EndOfMap",
                 "Parameters": Object {
                   "config": Object {
@@ -193,7 +188,6 @@ Array [
                 "Type": "Pass",
               },
               "MitochondrialContentFilter": Object {
-                "HeartbeatSeconds": 60,
                 "Next": "NumGenesVsNumUmisFilter",
                 "Parameters": Object {
                   "config": Object {},
@@ -208,7 +202,6 @@ Array [
                 "Type": "Task",
               },
               "NumGenesVsNumUmisFilter": Object {
-                "HeartbeatSeconds": 60,
                 "Next": "DoubletScoresFilter",
                 "Parameters": Object {
                   "config": Object {},

--- a/tests/api/general-services/__snapshots__/state-machine-definition.test.js.snap
+++ b/tests/api/general-services/__snapshots__/state-machine-definition.test.js.snap
@@ -52,7 +52,6 @@ exports[`non-tests to document the State Machines - local development 1`] = `
             "Type": "Task",
             "ResultPath": null,
             "TimeoutSeconds": 300,
-            "HeartbeatSeconds": 60,
             "Parameters": {
               "experimentId": "mock-experiment-id",
               "taskName": "classifier",
@@ -66,7 +65,6 @@ exports[`non-tests to document the State Machines - local development 1`] = `
             "Type": "Task",
             "ResultPath": null,
             "TimeoutSeconds": 300,
-            "HeartbeatSeconds": 60,
             "Parameters": {
               "experimentId": "mock-experiment-id",
               "taskName": "cellSizeDistribution",
@@ -80,7 +78,6 @@ exports[`non-tests to document the State Machines - local development 1`] = `
             "Type": "Task",
             "ResultPath": null,
             "TimeoutSeconds": 300,
-            "HeartbeatSeconds": 60,
             "Parameters": {
               "experimentId": "mock-experiment-id",
               "taskName": "mitochondrialContent",
@@ -94,7 +91,6 @@ exports[`non-tests to document the State Machines - local development 1`] = `
             "Type": "Task",
             "ResultPath": null,
             "TimeoutSeconds": 300,
-            "HeartbeatSeconds": 60,
             "Parameters": {
               "experimentId": "mock-experiment-id",
               "taskName": "numGenesVsNumUmis",
@@ -108,7 +104,6 @@ exports[`non-tests to document the State Machines - local development 1`] = `
             "Type": "Task",
             "ResultPath": null,
             "TimeoutSeconds": 300,
-            "HeartbeatSeconds": 60,
             "Parameters": {
               "experimentId": "mock-experiment-id",
               "taskName": "doubletScores",
@@ -129,7 +124,6 @@ exports[`non-tests to document the State Machines - local development 1`] = `
       "Type": "Task",
       "ResultPath": null,
       "TimeoutSeconds": 300,
-      "HeartbeatSeconds": 60,
       "Parameters": {
         "experimentId": "mock-experiment-id",
         "taskName": "dataIntegration",
@@ -143,7 +137,6 @@ exports[`non-tests to document the State Machines - local development 1`] = `
       "Type": "Task",
       "ResultPath": null,
       "TimeoutSeconds": 300,
-      "HeartbeatSeconds": 60,
       "Parameters": {
         "experimentId": "mock-experiment-id",
         "taskName": "configureEmbedding",
@@ -257,7 +250,6 @@ exports[`non-tests to document the State Machines -cloud 1`] = `
             "Type": "Task",
             "ResultPath": null,
             "TimeoutSeconds": 300,
-            "HeartbeatSeconds": 60,
             "Parameters": {
               "experimentId": "mock-experiment-id",
               "taskName": "classifier",
@@ -271,7 +263,6 @@ exports[`non-tests to document the State Machines -cloud 1`] = `
             "Type": "Task",
             "ResultPath": null,
             "TimeoutSeconds": 300,
-            "HeartbeatSeconds": 60,
             "Parameters": {
               "experimentId": "mock-experiment-id",
               "taskName": "cellSizeDistribution",
@@ -285,7 +276,6 @@ exports[`non-tests to document the State Machines -cloud 1`] = `
             "Type": "Task",
             "ResultPath": null,
             "TimeoutSeconds": 300,
-            "HeartbeatSeconds": 60,
             "Parameters": {
               "experimentId": "mock-experiment-id",
               "taskName": "mitochondrialContent",
@@ -299,7 +289,6 @@ exports[`non-tests to document the State Machines -cloud 1`] = `
             "Type": "Task",
             "ResultPath": null,
             "TimeoutSeconds": 300,
-            "HeartbeatSeconds": 60,
             "Parameters": {
               "experimentId": "mock-experiment-id",
               "taskName": "numGenesVsNumUmis",
@@ -313,7 +302,6 @@ exports[`non-tests to document the State Machines -cloud 1`] = `
             "Type": "Task",
             "ResultPath": null,
             "TimeoutSeconds": 300,
-            "HeartbeatSeconds": 60,
             "Parameters": {
               "experimentId": "mock-experiment-id",
               "taskName": "doubletScores",
@@ -334,7 +322,6 @@ exports[`non-tests to document the State Machines -cloud 1`] = `
       "Type": "Task",
       "ResultPath": null,
       "TimeoutSeconds": 300,
-      "HeartbeatSeconds": 60,
       "Parameters": {
         "experimentId": "mock-experiment-id",
         "taskName": "dataIntegration",
@@ -348,7 +335,6 @@ exports[`non-tests to document the State Machines -cloud 1`] = `
       "Type": "Task",
       "ResultPath": null,
       "TimeoutSeconds": 300,
-      "HeartbeatSeconds": 60,
       "Parameters": {
         "experimentId": "mock-experiment-id",
         "taskName": "configureEmbedding",

--- a/tests/api/general-services/__snapshots__/state-machine-definition.test.js.snap
+++ b/tests/api/general-services/__snapshots__/state-machine-definition.test.js.snap
@@ -17,7 +17,7 @@ exports[`non-tests to document the State Machines - local development 1`] = `
       }
     },
     "LaunchNewPipelineWorker": {
-      "Next": "Filters",
+      "Next": "ClassifierFilterMap",
       "ResultPath": null,
       "Type": "Task",
       "Resource": "arn:aws:states:::lambda:invoke",
@@ -35,20 +35,20 @@ exports[`non-tests to document the State Machines - local development 1`] = `
             "States.ALL"
           ],
           "ResultPath": "$.error-info",
-          "Next": "Filters"
+          "Next": "ClassifierFilterMap"
         }
       ]
     },
-    "Filters": {
+    "ClassifierFilterMap": {
       "Type": "Map",
-      "Next": "DataIntegration",
-      "MaxConcurrency": 1,
+      "Next": "CellSizeDistributionFilterMap",
+      "ResultPath": null,
       "ItemsPath": "$.samples",
       "Iterator": {
         "StartAt": "ClassifierFilter",
         "States": {
           "ClassifierFilter": {
-            "Next": "CellSizeDistributionFilter",
+            "End": true,
             "Type": "Task",
             "ResultPath": null,
             "TimeoutSeconds": 300,
@@ -59,9 +59,20 @@ exports[`non-tests to document the State Machines - local development 1`] = `
               "server": "host.docker.internal",
               "sampleUuid.$": "$.sampleUuid"
             }
-          },
+          }
+        }
+      }
+    },
+    "CellSizeDistributionFilterMap": {
+      "Type": "Map",
+      "Next": "MitochondrialContentFilterMap",
+      "ResultPath": null,
+      "ItemsPath": "$.samples",
+      "Iterator": {
+        "StartAt": "CellSizeDistributionFilter",
+        "States": {
           "CellSizeDistributionFilter": {
-            "Next": "MitochondrialContentFilter",
+            "End": true,
             "Type": "Task",
             "ResultPath": null,
             "TimeoutSeconds": 300,
@@ -72,9 +83,20 @@ exports[`non-tests to document the State Machines - local development 1`] = `
               "server": "host.docker.internal",
               "sampleUuid.$": "$.sampleUuid"
             }
-          },
+          }
+        }
+      }
+    },
+    "MitochondrialContentFilterMap": {
+      "Type": "Map",
+      "Next": "NumGenesVsNumUmisFilterMap",
+      "ResultPath": null,
+      "ItemsPath": "$.samples",
+      "Iterator": {
+        "StartAt": "MitochondrialContentFilter",
+        "States": {
           "MitochondrialContentFilter": {
-            "Next": "NumGenesVsNumUmisFilter",
+            "End": true,
             "Type": "Task",
             "ResultPath": null,
             "TimeoutSeconds": 300,
@@ -85,9 +107,20 @@ exports[`non-tests to document the State Machines - local development 1`] = `
               "server": "host.docker.internal",
               "sampleUuid.$": "$.sampleUuid"
             }
-          },
+          }
+        }
+      }
+    },
+    "NumGenesVsNumUmisFilterMap": {
+      "Type": "Map",
+      "Next": "DoubletScoresFilterMap",
+      "ResultPath": null,
+      "ItemsPath": "$.samples",
+      "Iterator": {
+        "StartAt": "NumGenesVsNumUmisFilter",
+        "States": {
           "NumGenesVsNumUmisFilter": {
-            "Next": "DoubletScoresFilter",
+            "End": true,
             "Type": "Task",
             "ResultPath": null,
             "TimeoutSeconds": 300,
@@ -98,9 +131,20 @@ exports[`non-tests to document the State Machines - local development 1`] = `
               "server": "host.docker.internal",
               "sampleUuid.$": "$.sampleUuid"
             }
-          },
+          }
+        }
+      }
+    },
+    "DoubletScoresFilterMap": {
+      "Type": "Map",
+      "Next": "DataIntegration",
+      "ResultPath": null,
+      "ItemsPath": "$.samples",
+      "Iterator": {
+        "StartAt": "DoubletScoresFilter",
+        "States": {
           "DoubletScoresFilter": {
-            "Next": "EndOfMap",
+            "End": true,
             "Type": "Task",
             "ResultPath": null,
             "TimeoutSeconds": 300,
@@ -111,10 +155,6 @@ exports[`non-tests to document the State Machines - local development 1`] = `
               "server": "host.docker.internal",
               "sampleUuid.$": "$.sampleUuid"
             }
-          },
-          "EndOfMap": {
-            "Type": "Pass",
-            "End": true
           }
         }
       }
@@ -179,7 +219,7 @@ exports[`non-tests to document the State Machines -cloud 1`] = `
       }
     },
     "LaunchNewPipelineWorker": {
-      "Next": "Filters",
+      "Next": "ClassifierFilterMap",
       "ResultPath": null,
       "Type": "Task",
       "Comment": "Attempts to create a Kubernetes Job+Service for the pipeline runner. Will swallow a 409 (already exists) error.",
@@ -235,20 +275,20 @@ exports[`non-tests to document the State Machines -cloud 1`] = `
             "EKS.409"
           ],
           "ResultPath": "$.error-info",
-          "Next": "Filters"
+          "Next": "ClassifierFilterMap"
         }
       ]
     },
-    "Filters": {
+    "ClassifierFilterMap": {
       "Type": "Map",
-      "Next": "DataIntegration",
-      "MaxConcurrency": 1,
+      "Next": "CellSizeDistributionFilterMap",
+      "ResultPath": null,
       "ItemsPath": "$.samples",
       "Iterator": {
         "StartAt": "ClassifierFilter",
         "States": {
           "ClassifierFilter": {
-            "Next": "CellSizeDistributionFilter",
+            "End": true,
             "Type": "Task",
             "ResultPath": null,
             "TimeoutSeconds": 300,
@@ -259,9 +299,20 @@ exports[`non-tests to document the State Machines -cloud 1`] = `
               "server": "remoter-server-mock-experiment-id.pipeline-test-namespace.svc.cluster.local",
               "sampleUuid.$": "$.sampleUuid"
             }
-          },
+          }
+        }
+      }
+    },
+    "CellSizeDistributionFilterMap": {
+      "Type": "Map",
+      "Next": "MitochondrialContentFilterMap",
+      "ResultPath": null,
+      "ItemsPath": "$.samples",
+      "Iterator": {
+        "StartAt": "CellSizeDistributionFilter",
+        "States": {
           "CellSizeDistributionFilter": {
-            "Next": "MitochondrialContentFilter",
+            "End": true,
             "Type": "Task",
             "ResultPath": null,
             "TimeoutSeconds": 300,
@@ -272,9 +323,20 @@ exports[`non-tests to document the State Machines -cloud 1`] = `
               "server": "remoter-server-mock-experiment-id.pipeline-test-namespace.svc.cluster.local",
               "sampleUuid.$": "$.sampleUuid"
             }
-          },
+          }
+        }
+      }
+    },
+    "MitochondrialContentFilterMap": {
+      "Type": "Map",
+      "Next": "NumGenesVsNumUmisFilterMap",
+      "ResultPath": null,
+      "ItemsPath": "$.samples",
+      "Iterator": {
+        "StartAt": "MitochondrialContentFilter",
+        "States": {
           "MitochondrialContentFilter": {
-            "Next": "NumGenesVsNumUmisFilter",
+            "End": true,
             "Type": "Task",
             "ResultPath": null,
             "TimeoutSeconds": 300,
@@ -285,9 +347,20 @@ exports[`non-tests to document the State Machines -cloud 1`] = `
               "server": "remoter-server-mock-experiment-id.pipeline-test-namespace.svc.cluster.local",
               "sampleUuid.$": "$.sampleUuid"
             }
-          },
+          }
+        }
+      }
+    },
+    "NumGenesVsNumUmisFilterMap": {
+      "Type": "Map",
+      "Next": "DoubletScoresFilterMap",
+      "ResultPath": null,
+      "ItemsPath": "$.samples",
+      "Iterator": {
+        "StartAt": "NumGenesVsNumUmisFilter",
+        "States": {
           "NumGenesVsNumUmisFilter": {
-            "Next": "DoubletScoresFilter",
+            "End": true,
             "Type": "Task",
             "ResultPath": null,
             "TimeoutSeconds": 300,
@@ -298,9 +371,20 @@ exports[`non-tests to document the State Machines -cloud 1`] = `
               "server": "remoter-server-mock-experiment-id.pipeline-test-namespace.svc.cluster.local",
               "sampleUuid.$": "$.sampleUuid"
             }
-          },
+          }
+        }
+      }
+    },
+    "DoubletScoresFilterMap": {
+      "Type": "Map",
+      "Next": "DataIntegration",
+      "ResultPath": null,
+      "ItemsPath": "$.samples",
+      "Iterator": {
+        "StartAt": "DoubletScoresFilter",
+        "States": {
           "DoubletScoresFilter": {
-            "Next": "EndOfMap",
+            "End": true,
             "Type": "Task",
             "ResultPath": null,
             "TimeoutSeconds": 300,
@@ -311,10 +395,6 @@ exports[`non-tests to document the State Machines -cloud 1`] = `
               "server": "remoter-server-mock-experiment-id.pipeline-test-namespace.svc.cluster.local",
               "sampleUuid.$": "$.sampleUuid"
             }
-          },
-          "EndOfMap": {
-            "Type": "Pass",
-            "End": true
           }
         }
       }

--- a/tests/api/general-services/__snapshots__/state-machine-definition.test.js.snap
+++ b/tests/api/general-services/__snapshots__/state-machine-definition.test.js.snap
@@ -24,8 +24,8 @@ exports[`non-tests to document the State Machines - local development 1`] = `
       "Parameters": {
         "FunctionName": "arn:aws:lambda:eu-west-1:mock-account-id:function:local-container-launcher",
         "Payload": {
-          "image": "biomage-remoter-server",
-          "name": "pipeline-remoter-server",
+          "image": "biomage-qc-runner",
+          "name": "pipeline-qc-runner",
           "detached": true
         }
       },
@@ -50,127 +50,72 @@ exports[`non-tests to document the State Machines - local development 1`] = `
           "ClassifierFilter": {
             "Next": "CellSizeDistributionFilter",
             "Type": "Task",
-            "Resource": "arn:aws:states:::lambda:invoke",
             "ResultPath": null,
+            "TimeoutSeconds": 300,
+            "HeartbeatSeconds": 60,
             "Parameters": {
-              "FunctionName": "arn:aws:lambda:eu-west-1:mock-account-id:function:local-container-launcher",
-              "Payload": {
-                "image": "biomage-remoter-client",
-                "name": "pipeline-remoter-client",
-                "task": "{\\"experimentId\\":\\"mock-experiment-id\\",\\"taskName\\":\\"classifier\\",\\"config\\":{},\\"server\\":\\"host.docker.internal\\"}",
-                "sampleUuid.$": "$.sampleUuid",
-                "detached": false
-              }
-            },
-            "Catch": [
-              {
-                "ErrorEquals": [
-                  "States.ALL"
-                ],
-                "ResultPath": "$.error-info",
-                "Next": "CellSizeDistributionFilter"
-              }
-            ]
+              "experimentId": "mock-experiment-id",
+              "taskName": "classifier",
+              "config": {},
+              "server": "host.docker.internal",
+              "sampleUuid.$": "$.sampleUuid"
+            }
           },
           "CellSizeDistributionFilter": {
             "Next": "MitochondrialContentFilter",
             "Type": "Task",
-            "Resource": "arn:aws:states:::lambda:invoke",
             "ResultPath": null,
+            "TimeoutSeconds": 300,
+            "HeartbeatSeconds": 60,
             "Parameters": {
-              "FunctionName": "arn:aws:lambda:eu-west-1:mock-account-id:function:local-container-launcher",
-              "Payload": {
-                "image": "biomage-remoter-client",
-                "name": "pipeline-remoter-client",
-                "task": "{\\"experimentId\\":\\"mock-experiment-id\\",\\"taskName\\":\\"cellSizeDistribution\\",\\"config\\":{},\\"server\\":\\"host.docker.internal\\"}",
-                "sampleUuid.$": "$.sampleUuid",
-                "detached": false
-              }
-            },
-            "Catch": [
-              {
-                "ErrorEquals": [
-                  "States.ALL"
-                ],
-                "ResultPath": "$.error-info",
-                "Next": "MitochondrialContentFilter"
-              }
-            ]
+              "experimentId": "mock-experiment-id",
+              "taskName": "cellSizeDistribution",
+              "config": {},
+              "server": "host.docker.internal",
+              "sampleUuid.$": "$.sampleUuid"
+            }
           },
           "MitochondrialContentFilter": {
             "Next": "NumGenesVsNumUmisFilter",
             "Type": "Task",
-            "Resource": "arn:aws:states:::lambda:invoke",
             "ResultPath": null,
+            "TimeoutSeconds": 300,
+            "HeartbeatSeconds": 60,
             "Parameters": {
-              "FunctionName": "arn:aws:lambda:eu-west-1:mock-account-id:function:local-container-launcher",
-              "Payload": {
-                "image": "biomage-remoter-client",
-                "name": "pipeline-remoter-client",
-                "task": "{\\"experimentId\\":\\"mock-experiment-id\\",\\"taskName\\":\\"mitochondrialContent\\",\\"config\\":{},\\"server\\":\\"host.docker.internal\\"}",
-                "sampleUuid.$": "$.sampleUuid",
-                "detached": false
-              }
-            },
-            "Catch": [
-              {
-                "ErrorEquals": [
-                  "States.ALL"
-                ],
-                "ResultPath": "$.error-info",
-                "Next": "NumGenesVsNumUmisFilter"
-              }
-            ]
+              "experimentId": "mock-experiment-id",
+              "taskName": "mitochondrialContent",
+              "config": {},
+              "server": "host.docker.internal",
+              "sampleUuid.$": "$.sampleUuid"
+            }
           },
           "NumGenesVsNumUmisFilter": {
             "Next": "DoubletScoresFilter",
             "Type": "Task",
-            "Resource": "arn:aws:states:::lambda:invoke",
             "ResultPath": null,
+            "TimeoutSeconds": 300,
+            "HeartbeatSeconds": 60,
             "Parameters": {
-              "FunctionName": "arn:aws:lambda:eu-west-1:mock-account-id:function:local-container-launcher",
-              "Payload": {
-                "image": "biomage-remoter-client",
-                "name": "pipeline-remoter-client",
-                "task": "{\\"experimentId\\":\\"mock-experiment-id\\",\\"taskName\\":\\"numGenesVsNumUmis\\",\\"config\\":{},\\"server\\":\\"host.docker.internal\\"}",
-                "sampleUuid.$": "$.sampleUuid",
-                "detached": false
-              }
-            },
-            "Catch": [
-              {
-                "ErrorEquals": [
-                  "States.ALL"
-                ],
-                "ResultPath": "$.error-info",
-                "Next": "DoubletScoresFilter"
-              }
-            ]
+              "experimentId": "mock-experiment-id",
+              "taskName": "numGenesVsNumUmis",
+              "config": {},
+              "server": "host.docker.internal",
+              "sampleUuid.$": "$.sampleUuid"
+            }
           },
           "DoubletScoresFilter": {
-            "End": true,
+            "Next": "EndOfMap",
             "Type": "Task",
-            "Resource": "arn:aws:states:::lambda:invoke",
             "ResultPath": null,
+            "TimeoutSeconds": 300,
+            "HeartbeatSeconds": 60,
             "Parameters": {
-              "FunctionName": "arn:aws:lambda:eu-west-1:mock-account-id:function:local-container-launcher",
-              "Payload": {
-                "image": "biomage-remoter-client",
-                "name": "pipeline-remoter-client",
-                "task": "{\\"experimentId\\":\\"mock-experiment-id\\",\\"taskName\\":\\"doubletScores\\",\\"config\\":{},\\"server\\":\\"host.docker.internal\\"}",
-                "sampleUuid.$": "$.sampleUuid",
-                "detached": false
-              }
-            },
-            "Catch": [
-              {
-                "ErrorEquals": [
-                  "States.ALL"
-                ],
-                "ResultPath": "$.error-info",
-                "Next": "EndOfMap"
-              }
-            ]
+              "experimentId": "mock-experiment-id",
+              "taskName": "doubletScores",
+              "config": {},
+              "server": "host.docker.internal",
+              "sampleUuid.$": "$.sampleUuid"
+            }
           },
           "EndOfMap": {
             "Type": "Pass",
@@ -182,50 +127,30 @@ exports[`non-tests to document the State Machines - local development 1`] = `
     "DataIntegration": {
       "Next": "ConfigureEmbedding",
       "Type": "Task",
-      "Resource": "arn:aws:states:::lambda:invoke",
       "ResultPath": null,
+      "TimeoutSeconds": 300,
+      "HeartbeatSeconds": 60,
       "Parameters": {
-        "FunctionName": "arn:aws:lambda:eu-west-1:mock-account-id:function:local-container-launcher",
-        "Payload": {
-          "image": "biomage-remoter-client",
-          "name": "pipeline-remoter-client",
-          "task": "{\\"experimentId\\":\\"mock-experiment-id\\",\\"taskName\\":\\"dataIntegration\\",\\"config\\":{},\\"server\\":\\"host.docker.internal\\"}",
-          "detached": false
-        }
-      },
-      "Catch": [
-        {
-          "ErrorEquals": [
-            "States.ALL"
-          ],
-          "ResultPath": "$.error-info",
-          "Next": "ConfigureEmbedding"
-        }
-      ]
+        "experimentId": "mock-experiment-id",
+        "taskName": "dataIntegration",
+        "config": {},
+        "server": "host.docker.internal",
+        "sampleUuid": ""
+      }
     },
     "ConfigureEmbedding": {
-      "End": true,
+      "Next": "EndOfPipeline",
       "Type": "Task",
-      "Resource": "arn:aws:states:::lambda:invoke",
       "ResultPath": null,
+      "TimeoutSeconds": 300,
+      "HeartbeatSeconds": 60,
       "Parameters": {
-        "FunctionName": "arn:aws:lambda:eu-west-1:mock-account-id:function:local-container-launcher",
-        "Payload": {
-          "image": "biomage-remoter-client",
-          "name": "pipeline-remoter-client",
-          "task": "{\\"experimentId\\":\\"mock-experiment-id\\",\\"taskName\\":\\"configureEmbedding\\",\\"config\\":{},\\"server\\":\\"host.docker.internal\\"}",
-          "detached": false
-        }
-      },
-      "Catch": [
-        {
-          "ErrorEquals": [
-            "States.ALL"
-          ],
-          "ResultPath": "$.error-info",
-          "Next": "EndOfPipeline"
-        }
-      ]
+        "experimentId": "mock-experiment-id",
+        "taskName": "configureEmbedding",
+        "config": {},
+        "server": "host.docker.internal",
+        "sampleUuid": ""
+      }
     },
     "EndOfPipeline": {
       "Type": "Pass",
@@ -264,7 +189,7 @@ exports[`non-tests to document the State Machines -cloud 1`] = `
       "Next": "Filters",
       "ResultPath": null,
       "Type": "Task",
-      "Comment": "Attempts to create a Kubernetes Job+Service for the pipeline server. Will swallow a 409 (already exists) error.",
+      "Comment": "Attempts to create a Kubernetes Job+Service for the pipeline runner. Will swallow a 409 (already exists) error.",
       "Resource": "arn:aws:states:::eks:call",
       "Parameters": {
         "ClusterName": "mock-cluster-name",
@@ -276,24 +201,21 @@ exports[`non-tests to document the State Machines -cloud 1`] = `
           "apiVersion": "helm.fluxcd.io/v1",
           "kind": "HelmRelease",
           "metadata": {
-            "name": "remoter-server-mock-experiment-id",
+            "name": "pipeline-mock-experiment-id",
             "namespace": "pipeline-test-namespace",
             "annotations": {
               "fluxcd.io/automated": "true"
             },
-            "labels": {
-              "type": "pipeline"
-            }
+            "labels": {}
           },
           "spec": {
-            "releaseName": "remoter-server-mock-experiment-id",
+            "releaseName": "pipeline-mock-experiment-id",
             "chart": {
               "git": "git@github.com:biomage-ltd/pipeline",
-              "path": "remoter-server/chart"
+              "path": "qc-runner/chart"
             },
             "values": {
               "experimentId": "mock-experiment-id",
-              "image": "mock-remoter-server-image",
               "namespace": "pipeline-test-namespace",
               "awsAccountId": "mock-account-id",
               "clusterEnv": "test",
@@ -333,377 +255,72 @@ exports[`non-tests to document the State Machines -cloud 1`] = `
           "ClassifierFilter": {
             "Next": "CellSizeDistributionFilter",
             "Type": "Task",
-            "Comment": "Attempts to create a Kubernetes Job for the pipeline server. Will swallow a 409 (already exists) error.",
-            "Resource": "arn:aws:states:::eks:runJob.sync",
             "ResultPath": null,
+            "TimeoutSeconds": 300,
+            "HeartbeatSeconds": 60,
             "Parameters": {
-              "ClusterName": "mock-cluster-name",
-              "CertificateAuthority": "mock-ca",
-              "Endpoint": "mock-endpoint",
-              "Namespace": "pipeline-test-namespace",
-              "LogOptions": {
-                "RetrieveLogs": true
-              },
-              "Job": {
-                "apiVersion": "batch/v1",
-                "kind": "Job",
-                "metadata": {
-                  "name.$": "States.Format('remoter-client-6173646667-{}', $.index)",
-                  "labels": {
-                    "experimentId": "mock-experiment-id",
-                    "taskName": "classifier",
-                    "type": "pipeline"
-                  }
-                },
-                "spec": {
-                  "template": {
-                    "metadata": {
-                      "name.$": "States.Format('remoter-client-6173646667-{}', $.index)",
-                      "labels": {
-                        "type": "pipeline"
-                      }
-                    },
-                    "spec": {
-                      "containers": [
-                        {
-                          "name": "remoter-client",
-                          "image": "mock-remoter-client-image",
-                          "args": [
-                            "{\\"experimentId\\":\\"mock-experiment-id\\",\\"taskName\\":\\"classifier\\",\\"config\\":{},\\"server\\":\\"remoter-server-mock-experiment-id.pipeline-test-namespace.svc.cluster.local\\"}"
-                          ],
-                          "env": [
-                            {
-                              "name": "SAMPLE_ID",
-                              "value.$": "$.sampleUuid"
-                            }
-                          ]
-                        }
-                      ],
-                      "restartPolicy": "Never"
-                    }
-                  }
-                }
-              }
-            },
-            "Retry": [
-              {
-                "ErrorEquals": [
-                  "EKS.409"
-                ],
-                "IntervalSeconds": 1,
-                "BackoffRate": 2,
-                "MaxAttempts": 2
-              }
-            ],
-            "Catch": [
-              {
-                "ErrorEquals": [
-                  "EKS.409"
-                ],
-                "ResultPath": "$.error-info",
-                "Next": "CellSizeDistributionFilter"
-              }
-            ]
+              "experimentId": "mock-experiment-id",
+              "taskName": "classifier",
+              "config": {},
+              "server": "remoter-server-mock-experiment-id.pipeline-test-namespace.svc.cluster.local",
+              "sampleUuid.$": "$.sampleUuid"
+            }
           },
           "CellSizeDistributionFilter": {
             "Next": "MitochondrialContentFilter",
             "Type": "Task",
-            "Comment": "Attempts to create a Kubernetes Job for the pipeline server. Will swallow a 409 (already exists) error.",
-            "Resource": "arn:aws:states:::eks:runJob.sync",
             "ResultPath": null,
+            "TimeoutSeconds": 300,
+            "HeartbeatSeconds": 60,
             "Parameters": {
-              "ClusterName": "mock-cluster-name",
-              "CertificateAuthority": "mock-ca",
-              "Endpoint": "mock-endpoint",
-              "Namespace": "pipeline-test-namespace",
-              "LogOptions": {
-                "RetrieveLogs": true
-              },
-              "Job": {
-                "apiVersion": "batch/v1",
-                "kind": "Job",
-                "metadata": {
-                  "name.$": "States.Format('remoter-client-6173646667-{}', $.index)",
-                  "labels": {
-                    "experimentId": "mock-experiment-id",
-                    "taskName": "cellSizeDistribution",
-                    "type": "pipeline"
-                  }
-                },
-                "spec": {
-                  "template": {
-                    "metadata": {
-                      "name.$": "States.Format('remoter-client-6173646667-{}', $.index)",
-                      "labels": {
-                        "type": "pipeline"
-                      }
-                    },
-                    "spec": {
-                      "containers": [
-                        {
-                          "name": "remoter-client",
-                          "image": "mock-remoter-client-image",
-                          "args": [
-                            "{\\"experimentId\\":\\"mock-experiment-id\\",\\"taskName\\":\\"cellSizeDistribution\\",\\"config\\":{},\\"server\\":\\"remoter-server-mock-experiment-id.pipeline-test-namespace.svc.cluster.local\\"}"
-                          ],
-                          "env": [
-                            {
-                              "name": "SAMPLE_ID",
-                              "value.$": "$.sampleUuid"
-                            }
-                          ]
-                        }
-                      ],
-                      "restartPolicy": "Never"
-                    }
-                  }
-                }
-              }
-            },
-            "Retry": [
-              {
-                "ErrorEquals": [
-                  "EKS.409"
-                ],
-                "IntervalSeconds": 1,
-                "BackoffRate": 2,
-                "MaxAttempts": 2
-              }
-            ],
-            "Catch": [
-              {
-                "ErrorEquals": [
-                  "EKS.409"
-                ],
-                "ResultPath": "$.error-info",
-                "Next": "MitochondrialContentFilter"
-              }
-            ]
+              "experimentId": "mock-experiment-id",
+              "taskName": "cellSizeDistribution",
+              "config": {},
+              "server": "remoter-server-mock-experiment-id.pipeline-test-namespace.svc.cluster.local",
+              "sampleUuid.$": "$.sampleUuid"
+            }
           },
           "MitochondrialContentFilter": {
             "Next": "NumGenesVsNumUmisFilter",
             "Type": "Task",
-            "Comment": "Attempts to create a Kubernetes Job for the pipeline server. Will swallow a 409 (already exists) error.",
-            "Resource": "arn:aws:states:::eks:runJob.sync",
             "ResultPath": null,
+            "TimeoutSeconds": 300,
+            "HeartbeatSeconds": 60,
             "Parameters": {
-              "ClusterName": "mock-cluster-name",
-              "CertificateAuthority": "mock-ca",
-              "Endpoint": "mock-endpoint",
-              "Namespace": "pipeline-test-namespace",
-              "LogOptions": {
-                "RetrieveLogs": true
-              },
-              "Job": {
-                "apiVersion": "batch/v1",
-                "kind": "Job",
-                "metadata": {
-                  "name.$": "States.Format('remoter-client-6173646667-{}', $.index)",
-                  "labels": {
-                    "experimentId": "mock-experiment-id",
-                    "taskName": "mitochondrialContent",
-                    "type": "pipeline"
-                  }
-                },
-                "spec": {
-                  "template": {
-                    "metadata": {
-                      "name.$": "States.Format('remoter-client-6173646667-{}', $.index)",
-                      "labels": {
-                        "type": "pipeline"
-                      }
-                    },
-                    "spec": {
-                      "containers": [
-                        {
-                          "name": "remoter-client",
-                          "image": "mock-remoter-client-image",
-                          "args": [
-                            "{\\"experimentId\\":\\"mock-experiment-id\\",\\"taskName\\":\\"mitochondrialContent\\",\\"config\\":{},\\"server\\":\\"remoter-server-mock-experiment-id.pipeline-test-namespace.svc.cluster.local\\"}"
-                          ],
-                          "env": [
-                            {
-                              "name": "SAMPLE_ID",
-                              "value.$": "$.sampleUuid"
-                            }
-                          ]
-                        }
-                      ],
-                      "restartPolicy": "Never"
-                    }
-                  }
-                }
-              }
-            },
-            "Retry": [
-              {
-                "ErrorEquals": [
-                  "EKS.409"
-                ],
-                "IntervalSeconds": 1,
-                "BackoffRate": 2,
-                "MaxAttempts": 2
-              }
-            ],
-            "Catch": [
-              {
-                "ErrorEquals": [
-                  "EKS.409"
-                ],
-                "ResultPath": "$.error-info",
-                "Next": "NumGenesVsNumUmisFilter"
-              }
-            ]
+              "experimentId": "mock-experiment-id",
+              "taskName": "mitochondrialContent",
+              "config": {},
+              "server": "remoter-server-mock-experiment-id.pipeline-test-namespace.svc.cluster.local",
+              "sampleUuid.$": "$.sampleUuid"
+            }
           },
           "NumGenesVsNumUmisFilter": {
             "Next": "DoubletScoresFilter",
             "Type": "Task",
-            "Comment": "Attempts to create a Kubernetes Job for the pipeline server. Will swallow a 409 (already exists) error.",
-            "Resource": "arn:aws:states:::eks:runJob.sync",
             "ResultPath": null,
+            "TimeoutSeconds": 300,
+            "HeartbeatSeconds": 60,
             "Parameters": {
-              "ClusterName": "mock-cluster-name",
-              "CertificateAuthority": "mock-ca",
-              "Endpoint": "mock-endpoint",
-              "Namespace": "pipeline-test-namespace",
-              "LogOptions": {
-                "RetrieveLogs": true
-              },
-              "Job": {
-                "apiVersion": "batch/v1",
-                "kind": "Job",
-                "metadata": {
-                  "name.$": "States.Format('remoter-client-6173646667-{}', $.index)",
-                  "labels": {
-                    "experimentId": "mock-experiment-id",
-                    "taskName": "numGenesVsNumUmis",
-                    "type": "pipeline"
-                  }
-                },
-                "spec": {
-                  "template": {
-                    "metadata": {
-                      "name.$": "States.Format('remoter-client-6173646667-{}', $.index)",
-                      "labels": {
-                        "type": "pipeline"
-                      }
-                    },
-                    "spec": {
-                      "containers": [
-                        {
-                          "name": "remoter-client",
-                          "image": "mock-remoter-client-image",
-                          "args": [
-                            "{\\"experimentId\\":\\"mock-experiment-id\\",\\"taskName\\":\\"numGenesVsNumUmis\\",\\"config\\":{},\\"server\\":\\"remoter-server-mock-experiment-id.pipeline-test-namespace.svc.cluster.local\\"}"
-                          ],
-                          "env": [
-                            {
-                              "name": "SAMPLE_ID",
-                              "value.$": "$.sampleUuid"
-                            }
-                          ]
-                        }
-                      ],
-                      "restartPolicy": "Never"
-                    }
-                  }
-                }
-              }
-            },
-            "Retry": [
-              {
-                "ErrorEquals": [
-                  "EKS.409"
-                ],
-                "IntervalSeconds": 1,
-                "BackoffRate": 2,
-                "MaxAttempts": 2
-              }
-            ],
-            "Catch": [
-              {
-                "ErrorEquals": [
-                  "EKS.409"
-                ],
-                "ResultPath": "$.error-info",
-                "Next": "DoubletScoresFilter"
-              }
-            ]
+              "experimentId": "mock-experiment-id",
+              "taskName": "numGenesVsNumUmis",
+              "config": {},
+              "server": "remoter-server-mock-experiment-id.pipeline-test-namespace.svc.cluster.local",
+              "sampleUuid.$": "$.sampleUuid"
+            }
           },
           "DoubletScoresFilter": {
-            "End": true,
+            "Next": "EndOfMap",
             "Type": "Task",
-            "Comment": "Attempts to create a Kubernetes Job for the pipeline server. Will swallow a 409 (already exists) error.",
-            "Resource": "arn:aws:states:::eks:runJob.sync",
             "ResultPath": null,
+            "TimeoutSeconds": 300,
+            "HeartbeatSeconds": 60,
             "Parameters": {
-              "ClusterName": "mock-cluster-name",
-              "CertificateAuthority": "mock-ca",
-              "Endpoint": "mock-endpoint",
-              "Namespace": "pipeline-test-namespace",
-              "LogOptions": {
-                "RetrieveLogs": true
-              },
-              "Job": {
-                "apiVersion": "batch/v1",
-                "kind": "Job",
-                "metadata": {
-                  "name.$": "States.Format('remoter-client-6173646667-{}', $.index)",
-                  "labels": {
-                    "experimentId": "mock-experiment-id",
-                    "taskName": "doubletScores",
-                    "type": "pipeline"
-                  }
-                },
-                "spec": {
-                  "template": {
-                    "metadata": {
-                      "name.$": "States.Format('remoter-client-6173646667-{}', $.index)",
-                      "labels": {
-                        "type": "pipeline"
-                      }
-                    },
-                    "spec": {
-                      "containers": [
-                        {
-                          "name": "remoter-client",
-                          "image": "mock-remoter-client-image",
-                          "args": [
-                            "{\\"experimentId\\":\\"mock-experiment-id\\",\\"taskName\\":\\"doubletScores\\",\\"config\\":{},\\"server\\":\\"remoter-server-mock-experiment-id.pipeline-test-namespace.svc.cluster.local\\"}"
-                          ],
-                          "env": [
-                            {
-                              "name": "SAMPLE_ID",
-                              "value.$": "$.sampleUuid"
-                            }
-                          ]
-                        }
-                      ],
-                      "restartPolicy": "Never"
-                    }
-                  }
-                }
-              }
-            },
-            "Retry": [
-              {
-                "ErrorEquals": [
-                  "EKS.409"
-                ],
-                "IntervalSeconds": 1,
-                "BackoffRate": 2,
-                "MaxAttempts": 2
-              }
-            ],
-            "Catch": [
-              {
-                "ErrorEquals": [
-                  "EKS.409"
-                ],
-                "ResultPath": "$.error-info",
-                "Next": "EndOfMap"
-              }
-            ]
+              "experimentId": "mock-experiment-id",
+              "taskName": "doubletScores",
+              "config": {},
+              "server": "remoter-server-mock-experiment-id.pipeline-test-namespace.svc.cluster.local",
+              "sampleUuid.$": "$.sampleUuid"
+            }
           },
           "EndOfMap": {
             "Type": "Pass",
@@ -715,142 +332,30 @@ exports[`non-tests to document the State Machines -cloud 1`] = `
     "DataIntegration": {
       "Next": "ConfigureEmbedding",
       "Type": "Task",
-      "Comment": "Attempts to create a Kubernetes Job for the pipeline server. Will swallow a 409 (already exists) error.",
-      "Resource": "arn:aws:states:::eks:runJob.sync",
       "ResultPath": null,
+      "TimeoutSeconds": 300,
+      "HeartbeatSeconds": 60,
       "Parameters": {
-        "ClusterName": "mock-cluster-name",
-        "CertificateAuthority": "mock-ca",
-        "Endpoint": "mock-endpoint",
-        "Namespace": "pipeline-test-namespace",
-        "LogOptions": {
-          "RetrieveLogs": true
-        },
-        "Job": {
-          "apiVersion": "batch/v1",
-          "kind": "Job",
-          "metadata": {
-            "name": "remoter-client-6173646667",
-            "labels": {
-              "experimentId": "mock-experiment-id",
-              "taskName": "dataIntegration",
-              "type": "pipeline"
-            }
-          },
-          "spec": {
-            "template": {
-              "metadata": {
-                "name": "remoter-client-6173646667",
-                "labels": {
-                  "type": "pipeline"
-                }
-              },
-              "spec": {
-                "containers": [
-                  {
-                    "name": "remoter-client",
-                    "image": "mock-remoter-client-image",
-                    "args": [
-                      "{\\"experimentId\\":\\"mock-experiment-id\\",\\"taskName\\":\\"dataIntegration\\",\\"config\\":{},\\"server\\":\\"remoter-server-mock-experiment-id.pipeline-test-namespace.svc.cluster.local\\"}"
-                    ],
-                    "env": []
-                  }
-                ],
-                "restartPolicy": "Never"
-              }
-            }
-          }
-        }
-      },
-      "Retry": [
-        {
-          "ErrorEquals": [
-            "EKS.409"
-          ],
-          "IntervalSeconds": 1,
-          "BackoffRate": 2,
-          "MaxAttempts": 2
-        }
-      ],
-      "Catch": [
-        {
-          "ErrorEquals": [
-            "EKS.409"
-          ],
-          "ResultPath": "$.error-info",
-          "Next": "ConfigureEmbedding"
-        }
-      ]
+        "experimentId": "mock-experiment-id",
+        "taskName": "dataIntegration",
+        "config": {},
+        "server": "remoter-server-mock-experiment-id.pipeline-test-namespace.svc.cluster.local",
+        "sampleUuid": ""
+      }
     },
     "ConfigureEmbedding": {
-      "End": true,
+      "Next": "EndOfPipeline",
       "Type": "Task",
-      "Comment": "Attempts to create a Kubernetes Job for the pipeline server. Will swallow a 409 (already exists) error.",
-      "Resource": "arn:aws:states:::eks:runJob.sync",
       "ResultPath": null,
+      "TimeoutSeconds": 300,
+      "HeartbeatSeconds": 60,
       "Parameters": {
-        "ClusterName": "mock-cluster-name",
-        "CertificateAuthority": "mock-ca",
-        "Endpoint": "mock-endpoint",
-        "Namespace": "pipeline-test-namespace",
-        "LogOptions": {
-          "RetrieveLogs": true
-        },
-        "Job": {
-          "apiVersion": "batch/v1",
-          "kind": "Job",
-          "metadata": {
-            "name": "remoter-client-6173646667",
-            "labels": {
-              "experimentId": "mock-experiment-id",
-              "taskName": "configureEmbedding",
-              "type": "pipeline"
-            }
-          },
-          "spec": {
-            "template": {
-              "metadata": {
-                "name": "remoter-client-6173646667",
-                "labels": {
-                  "type": "pipeline"
-                }
-              },
-              "spec": {
-                "containers": [
-                  {
-                    "name": "remoter-client",
-                    "image": "mock-remoter-client-image",
-                    "args": [
-                      "{\\"experimentId\\":\\"mock-experiment-id\\",\\"taskName\\":\\"configureEmbedding\\",\\"config\\":{},\\"server\\":\\"remoter-server-mock-experiment-id.pipeline-test-namespace.svc.cluster.local\\"}"
-                    ],
-                    "env": []
-                  }
-                ],
-                "restartPolicy": "Never"
-              }
-            }
-          }
-        }
-      },
-      "Retry": [
-        {
-          "ErrorEquals": [
-            "EKS.409"
-          ],
-          "IntervalSeconds": 1,
-          "BackoffRate": 2,
-          "MaxAttempts": 2
-        }
-      ],
-      "Catch": [
-        {
-          "ErrorEquals": [
-            "EKS.409"
-          ],
-          "ResultPath": "$.error-info",
-          "Next": "EndOfPipeline"
-        }
-      ]
+        "experimentId": "mock-experiment-id",
+        "taskName": "configureEmbedding",
+        "config": {},
+        "server": "remoter-server-mock-experiment-id.pipeline-test-namespace.svc.cluster.local",
+        "sampleUuid": ""
+      }
     },
     "EndOfPipeline": {
       "Type": "Pass",

--- a/tests/api/general-services/__snapshots__/state-machine-definition.test.js.snap
+++ b/tests/api/general-services/__snapshots__/state-machine-definition.test.js.snap
@@ -199,7 +199,9 @@ exports[`non-tests to document the State Machines -cloud 1`] = `
             "annotations": {
               "fluxcd.io/automated": "true"
             },
-            "labels": {}
+            "labels": {
+              "type": "pipeline"
+            }
           },
           "spec": {
             "releaseName": "pipeline-mock-experiment-id",

--- a/tests/api/general-services/pipeline-manage.test.js
+++ b/tests/api/general-services/pipeline-manage.test.js
@@ -108,6 +108,12 @@ describe('test for pipeline services', () => {
       callback(null, { stateMachineArn: 'test-machine' });
     });
 
+    const createActivitySpy = jest.fn((x) => x);
+    AWSMock.mock('StepFunctions', 'createActivity', (params, callback) => {
+      createActivitySpy(params);
+      callback(null, { activityArn: 'test-actvitiy' });
+    });
+
     const startExecutionSpy = jest.fn((x) => x);
     AWSMock.mock('StepFunctions', 'startExecution', (params, callback) => {
       startExecutionSpy(params);
@@ -134,6 +140,7 @@ describe('test for pipeline services', () => {
     expect(getProcessingConfigSpy).toHaveBeenCalled();
     expect(getSamplesSpy).toHaveBeenCalled();
 
+    expect(createActivitySpy).toHaveBeenCalled();
     expect(startExecutionSpy).toHaveBeenCalled();
     expect(startExecutionSpy.mock.results).toMatchSnapshot();
   });
@@ -167,6 +174,12 @@ describe('test for pipeline services', () => {
     AWSMock.mock('StepFunctions', 'createStateMachine', (params, callback) => {
       createStateMachineSpy(params);
       callback(null, { stateMachineArn: 'test-machine' });
+    });
+
+    const createActivitySpy = jest.fn((x) => x);
+    AWSMock.mock('StepFunctions', 'createActivity', (params, callback) => {
+      createActivitySpy(params);
+      callback(null, { activityArn: 'test-actvitiy' });
     });
 
     AWSMock.mock('StepFunctions', 'startExecution', (params, callback) => {
@@ -204,6 +217,12 @@ describe('test for pipeline services', () => {
       callback(null, { stateMachineArn: 'test-machine' });
     });
 
+    const createActivitySpy = jest.fn((x) => x);
+    AWSMock.mock('StepFunctions', 'createActivity', (params, callback) => {
+      createActivitySpy(params);
+      callback(null, { activityArn: 'test-actvitiy' });
+    });
+
     const startExecutionSpy = jest.fn((x) => x);
     AWSMock.mock('StepFunctions', 'startExecution', (params, callback) => {
       startExecutionSpy(params);
@@ -217,6 +236,7 @@ describe('test for pipeline services', () => {
     expect(updateStateMachineSpy).toHaveBeenCalled();
     expect(updateStateMachineSpy.mock.results).toMatchSnapshot();
 
+    expect(createActivitySpy).toHaveBeenCalled();
     expect(startExecutionSpy).toHaveBeenCalled();
     expect(startExecutionSpy.mock.results).toMatchSnapshot();
   });


### PR DESCRIPTION
# Background
#### Link to issue 
https://biomage.atlassian.net/browse/BIOMAGE-709

#### Link to staging deployment URL 
TBD

#### Links to any Pull Requests related to this
https://github.com/biomage-ltd/pipeline/pull/28

#### Anything else the reviewers should know about the changes here
N/A

# Changes
### Code changes
API is slightly refactored to support activities. Only one job (old pipeline server) is launched, the "clients" are substituted with activities in AWS Step Functions.

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [x] Tested locally with Inframock
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
