### PR TITLE
Removed duplicated pipelineInstanceConfigUrl

### DIFF
--- a/src/config/default-config.js
+++ b/src/config/default-config.js
@@ -86,7 +86,7 @@ if (config.clusterEnv === 'development') {
     s3ForcePathStyle: true,
   });
 
-  config.pipelineInstanceConfigUrl = 'https://github.com/biomage-ltd/iac/blob/master/releases/production/pipeline.yaml';
+  config.pipelineInstanceConfigUrl = 'https://raw.githubusercontent.com/biomage-ltd/iac/master/releases/production/pipeline.yaml';
 
   config.corsOriginUrl = 'http://localhost:5000';
 }

--- a/src/config/test-config.js
+++ b/src/config/test-config.js
@@ -15,7 +15,7 @@ module.exports = {
   workerNamespace: 'worker-test-namespace',
   pipelineNamespace: 'pipeline-test-namespace',
   workerInstanceConfigUrl: 'https://raw.githubusercontent.com/biomage-ltd/iac/master/releases/production/worker.yaml',
-  pipelineInstanceConfigUrl: 'https://github.com/biomage-ltd/iac/blob/master/releases/production/pipeline.yaml',
+  pipelineInstanceConfigUrl: 'https://raw.githubusercontent.com/biomage-ltd/iac/master/releases/production/pipeline.yaml',
   api: {
     prefix: '/',
   },


### PR DESCRIPTION
# Background
#### Link to issue 

pipelineInstanceConfigUrl was pointing to the incorrect URL (normal one instead of raw) causing the `unexpected end of JSON file` error. 


#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

The correct URL is the same as the default value so removing it fixes the issue.


# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [x] Tested locally with Inframock
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
