### PR TITLE
[BIOMAGE-1027] Add safeBatchGetItem that divides batchGetItem in groups of requests of 100 keys

### DIFF
--- a/src/api/route-services/experiment.js
+++ b/src/api/route-services/experiment.js
@@ -5,8 +5,9 @@ const mockData = require('./mock-data.json');
 
 const AWS = require('../../utils/requireAWS');
 const logger = require('../../utils/logging');
-
 const { OK, NotFoundError } = require('../../utils/responses');
+const safeBatchGetItem = require('../../utils/safeBatchGetItem');
+
 const constants = require('../general-services/pipeline-manage/constants');
 
 const {
@@ -47,7 +48,7 @@ class ExperimentService {
     };
 
     try {
-      const response = await dynamodb.batchGetItem(params).promise();
+      const response = await safeBatchGetItem(dynamodb, params);
 
       return response.Responses[this.experimentsTableName].map(
         (experiment) => convertToJsObject(experiment),

--- a/src/api/route-services/projects.js
+++ b/src/api/route-services/projects.js
@@ -5,6 +5,7 @@ const {
 const logger = require('../../utils/logging');
 
 const { OK, NotFoundError } = require('../../utils/responses');
+const safeBatchGetItem = require('../../utils/safeBatchGetItem');
 
 const SamplesService = require('./samples');
 const ExperimentService = require('./experiment');
@@ -119,7 +120,7 @@ class ProjectsService {
       },
     };
 
-    const data = await dynamodb.batchGetItem(params).promise();
+    const data = await safeBatchGetItem(dynamodb, params);
 
     const existingProjectIds = new Set(data.Responses[this.tableName].map((entry) => {
       const newData = convertToJsObject(entry);

--- a/src/utils/safeBatchGetItem.js
+++ b/src/utils/safeBatchGetItem.js
@@ -1,0 +1,65 @@
+const _ = require('lodash');
+
+const concatIfArray = (objValue, srcValue) => {
+  if (_.isArray(objValue) && _.isArray(srcValue)) {
+    return [...objValue, ...srcValue];
+  }
+
+  return undefined;
+};
+
+// DO NOT MODIFY, this value is specified in dynamodb docs
+const maxKeys = 100;
+
+/**
+ * A wrapper for dynamodb's batchGetItem
+ * This wrapper handles requests of more than 100 items at the same time
+ *  by splitting them into separate batchGetItems
+ *
+ * @param {*} dynamodb dynamodb sdk client
+ * @param {*} params params as would be passed to batchGetItem
+ * @returns The result as would be returned by batchGetItem
+ */
+const safeBatchGetItem = async (dynamodb, params) => {
+  const tableNames = [];
+  const chunkedKeysByTableName = {};
+
+  let amountOfRequests = 0;
+
+  Object.entries(params.RequestItems).forEach(([tableName, { Keys: keys }]) => {
+    tableNames.push(tableName);
+    chunkedKeysByTableName[tableName] = _.chunk(keys, maxKeys);
+
+    amountOfRequests = Math.max(chunkedKeysByTableName[tableName].length, amountOfRequests);
+  });
+
+  const requestPromises = _.range(amountOfRequests).map(async (index) => {
+    const currentKeys = {};
+
+    tableNames.forEach((tableName) => {
+      const keysForTable = chunkedKeysByTableName[tableName][index];
+
+      if (keysForTable) {
+        currentKeys[tableName] = { Keys: keysForTable };
+      }
+    });
+
+    const chunkParams = {
+      ...params,
+      RequestItems: currentKeys,
+    };
+
+    return dynamodb.batchGetItem(chunkParams).promise();
+  });
+
+  const getResults = await Promise.all(requestPromises);
+
+  const flattenedResult = getResults.reduce((acc, curr) => {
+    _.mergeWith(acc, curr, concatIfArray);
+    return acc;
+  }, {});
+
+  return flattenedResult;
+};
+
+module.exports = safeBatchGetItem;

--- a/src/utils/safeBatchGetItem.js
+++ b/src/utils/safeBatchGetItem.js
@@ -39,8 +39,13 @@ const safeBatchGetItem = async (dynamodb, params) => {
     tableNames.forEach((tableName) => {
       const keysForTable = chunkedKeysByTableName[tableName][index];
 
+      const { Keys, ...restOfParams } = params.RequestItems[tableName];
+
       if (keysForTable) {
-        currentKeys[tableName] = { Keys: keysForTable };
+        currentKeys[tableName] = {
+          ...restOfParams,
+          Keys: keysForTable,
+        };
       }
     });
 

--- a/tests/utils/__snapshots__/safeBatchGetItem.test.js.snap
+++ b/tests/utils/__snapshots__/safeBatchGetItem.test.js.snap
@@ -1,0 +1,526 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`safeBatchGetItem Combines correctly the result when over 100 1`] = `
+Object {
+  "ConsumedCapacity": Array [],
+  "Responses": Object {
+    "tableName": Array [
+      Object {
+        "key": 1,
+      },
+      Object {
+        "key": 2,
+      },
+      Object {
+        "key": 1,
+      },
+      Object {
+        "key": 2,
+      },
+    ],
+  },
+  "UnprocessedKeys": Object {},
+}
+`;
+
+exports[`safeBatchGetItem Returns correctly the result when under 100 1`] = `
+Object {
+  "ConsumedCapacity": Array [],
+  "Responses": Object {
+    "tableName": Array [
+      Object {
+        "key": 1,
+      },
+      Object {
+        "key": 2,
+      },
+    ],
+  },
+  "UnprocessedKeys": Object {},
+}
+`;
+
+exports[`safeBatchGetItem splits the params if they exceed 100 keys 1`] = `
+Array [
+  Object {
+    "RequestItems": Object {
+      "tableName": Object {
+        "AttributesToGet": Array [
+          "attributeId",
+        ],
+        "ConsistentRead": true,
+        "ExpressionAttributeNames": Object {},
+        "Keys": Array [
+          Object {
+            "key": 0,
+          },
+          Object {
+            "key": 1,
+          },
+          Object {
+            "key": 2,
+          },
+          Object {
+            "key": 3,
+          },
+          Object {
+            "key": 4,
+          },
+          Object {
+            "key": 5,
+          },
+          Object {
+            "key": 6,
+          },
+          Object {
+            "key": 7,
+          },
+          Object {
+            "key": 8,
+          },
+          Object {
+            "key": 9,
+          },
+          Object {
+            "key": 10,
+          },
+          Object {
+            "key": 11,
+          },
+          Object {
+            "key": 12,
+          },
+          Object {
+            "key": 13,
+          },
+          Object {
+            "key": 14,
+          },
+          Object {
+            "key": 15,
+          },
+          Object {
+            "key": 16,
+          },
+          Object {
+            "key": 17,
+          },
+          Object {
+            "key": 18,
+          },
+          Object {
+            "key": 19,
+          },
+          Object {
+            "key": 20,
+          },
+          Object {
+            "key": 21,
+          },
+          Object {
+            "key": 22,
+          },
+          Object {
+            "key": 23,
+          },
+          Object {
+            "key": 24,
+          },
+          Object {
+            "key": 25,
+          },
+          Object {
+            "key": 26,
+          },
+          Object {
+            "key": 27,
+          },
+          Object {
+            "key": 28,
+          },
+          Object {
+            "key": 29,
+          },
+          Object {
+            "key": 30,
+          },
+          Object {
+            "key": 31,
+          },
+          Object {
+            "key": 32,
+          },
+          Object {
+            "key": 33,
+          },
+          Object {
+            "key": 34,
+          },
+          Object {
+            "key": 35,
+          },
+          Object {
+            "key": 36,
+          },
+          Object {
+            "key": 37,
+          },
+          Object {
+            "key": 38,
+          },
+          Object {
+            "key": 39,
+          },
+          Object {
+            "key": 40,
+          },
+          Object {
+            "key": 41,
+          },
+          Object {
+            "key": 42,
+          },
+          Object {
+            "key": 43,
+          },
+          Object {
+            "key": 44,
+          },
+          Object {
+            "key": 45,
+          },
+          Object {
+            "key": 46,
+          },
+          Object {
+            "key": 47,
+          },
+          Object {
+            "key": 48,
+          },
+          Object {
+            "key": 49,
+          },
+          Object {
+            "key": 50,
+          },
+          Object {
+            "key": 51,
+          },
+          Object {
+            "key": 52,
+          },
+          Object {
+            "key": 53,
+          },
+          Object {
+            "key": 54,
+          },
+          Object {
+            "key": 55,
+          },
+          Object {
+            "key": 56,
+          },
+          Object {
+            "key": 57,
+          },
+          Object {
+            "key": 58,
+          },
+          Object {
+            "key": 59,
+          },
+          Object {
+            "key": 60,
+          },
+          Object {
+            "key": 61,
+          },
+          Object {
+            "key": 62,
+          },
+          Object {
+            "key": 63,
+          },
+          Object {
+            "key": 64,
+          },
+          Object {
+            "key": 65,
+          },
+          Object {
+            "key": 66,
+          },
+          Object {
+            "key": 67,
+          },
+          Object {
+            "key": 68,
+          },
+          Object {
+            "key": 69,
+          },
+          Object {
+            "key": 70,
+          },
+          Object {
+            "key": 71,
+          },
+          Object {
+            "key": 72,
+          },
+          Object {
+            "key": 73,
+          },
+          Object {
+            "key": 74,
+          },
+          Object {
+            "key": 75,
+          },
+          Object {
+            "key": 76,
+          },
+          Object {
+            "key": 77,
+          },
+          Object {
+            "key": 78,
+          },
+          Object {
+            "key": 79,
+          },
+          Object {
+            "key": 80,
+          },
+          Object {
+            "key": 81,
+          },
+          Object {
+            "key": 82,
+          },
+          Object {
+            "key": 83,
+          },
+          Object {
+            "key": 84,
+          },
+          Object {
+            "key": 85,
+          },
+          Object {
+            "key": 86,
+          },
+          Object {
+            "key": 87,
+          },
+          Object {
+            "key": 88,
+          },
+          Object {
+            "key": 89,
+          },
+          Object {
+            "key": 90,
+          },
+          Object {
+            "key": 91,
+          },
+          Object {
+            "key": 92,
+          },
+          Object {
+            "key": 93,
+          },
+          Object {
+            "key": 94,
+          },
+          Object {
+            "key": 95,
+          },
+          Object {
+            "key": 96,
+          },
+          Object {
+            "key": 97,
+          },
+          Object {
+            "key": 98,
+          },
+          Object {
+            "key": 99,
+          },
+        ],
+        "ProjectionExpression": "projectionExpressionValue",
+      },
+    },
+    "ReturnConsumedCapacity": "returnConsumedCapacityValue",
+  },
+  Object {
+    "RequestItems": Object {
+      "tableName": Object {
+        "AttributesToGet": Array [
+          "attributeId",
+        ],
+        "ConsistentRead": true,
+        "ExpressionAttributeNames": Object {},
+        "Keys": Array [
+          Object {
+            "key": 100,
+          },
+          Object {
+            "key": 101,
+          },
+          Object {
+            "key": 102,
+          },
+          Object {
+            "key": 103,
+          },
+          Object {
+            "key": 104,
+          },
+          Object {
+            "key": 105,
+          },
+          Object {
+            "key": 106,
+          },
+          Object {
+            "key": 107,
+          },
+          Object {
+            "key": 108,
+          },
+          Object {
+            "key": 109,
+          },
+          Object {
+            "key": 110,
+          },
+          Object {
+            "key": 111,
+          },
+          Object {
+            "key": 112,
+          },
+          Object {
+            "key": 113,
+          },
+          Object {
+            "key": 114,
+          },
+          Object {
+            "key": 115,
+          },
+          Object {
+            "key": 116,
+          },
+          Object {
+            "key": 117,
+          },
+          Object {
+            "key": 118,
+          },
+          Object {
+            "key": 119,
+          },
+          Object {
+            "key": 120,
+          },
+          Object {
+            "key": 121,
+          },
+          Object {
+            "key": 122,
+          },
+          Object {
+            "key": 123,
+          },
+          Object {
+            "key": 124,
+          },
+          Object {
+            "key": 125,
+          },
+          Object {
+            "key": 126,
+          },
+          Object {
+            "key": 127,
+          },
+          Object {
+            "key": 128,
+          },
+          Object {
+            "key": 129,
+          },
+          Object {
+            "key": 130,
+          },
+          Object {
+            "key": 131,
+          },
+          Object {
+            "key": 132,
+          },
+          Object {
+            "key": 133,
+          },
+          Object {
+            "key": 134,
+          },
+          Object {
+            "key": 135,
+          },
+          Object {
+            "key": 136,
+          },
+          Object {
+            "key": 137,
+          },
+          Object {
+            "key": 138,
+          },
+          Object {
+            "key": 139,
+          },
+          Object {
+            "key": 140,
+          },
+          Object {
+            "key": 141,
+          },
+          Object {
+            "key": 142,
+          },
+          Object {
+            "key": 143,
+          },
+          Object {
+            "key": 144,
+          },
+          Object {
+            "key": 145,
+          },
+          Object {
+            "key": 146,
+          },
+          Object {
+            "key": 147,
+          },
+          Object {
+            "key": 148,
+          },
+          Object {
+            "key": 149,
+          },
+        ],
+        "ProjectionExpression": "projectionExpressionValue",
+      },
+    },
+    "ReturnConsumedCapacity": "returnConsumedCapacityValue",
+  },
+]
+`;

--- a/tests/utils/__snapshots__/safeBatchGetItem.test.js.snap
+++ b/tests/utils/__snapshots__/safeBatchGetItem.test.js.snap
@@ -23,7 +23,1929 @@ Object {
 }
 `;
 
+exports[`safeBatchGetItem Combines many tables correctly when over 100 1`] = `
+Array [
+  Object {
+    "RequestItems": Object {
+      "anotherTableName": Object {
+        "AttributesToGet": Array [
+          "attributeId",
+        ],
+        "ConsistentRead": true,
+        "ExpressionAttributeNames": Object {},
+        "Keys": Array [
+          Object {
+            "key": 0,
+          },
+          Object {
+            "key": 1,
+          },
+          Object {
+            "key": 2,
+          },
+          Object {
+            "key": 3,
+          },
+          Object {
+            "key": 4,
+          },
+          Object {
+            "key": 5,
+          },
+          Object {
+            "key": 6,
+          },
+          Object {
+            "key": 7,
+          },
+          Object {
+            "key": 8,
+          },
+          Object {
+            "key": 9,
+          },
+          Object {
+            "key": 10,
+          },
+          Object {
+            "key": 11,
+          },
+          Object {
+            "key": 12,
+          },
+          Object {
+            "key": 13,
+          },
+          Object {
+            "key": 14,
+          },
+          Object {
+            "key": 15,
+          },
+          Object {
+            "key": 16,
+          },
+          Object {
+            "key": 17,
+          },
+          Object {
+            "key": 18,
+          },
+          Object {
+            "key": 19,
+          },
+          Object {
+            "key": 20,
+          },
+          Object {
+            "key": 21,
+          },
+          Object {
+            "key": 22,
+          },
+          Object {
+            "key": 23,
+          },
+          Object {
+            "key": 24,
+          },
+          Object {
+            "key": 25,
+          },
+          Object {
+            "key": 26,
+          },
+          Object {
+            "key": 27,
+          },
+          Object {
+            "key": 28,
+          },
+          Object {
+            "key": 29,
+          },
+          Object {
+            "key": 30,
+          },
+          Object {
+            "key": 31,
+          },
+          Object {
+            "key": 32,
+          },
+          Object {
+            "key": 33,
+          },
+          Object {
+            "key": 34,
+          },
+          Object {
+            "key": 35,
+          },
+          Object {
+            "key": 36,
+          },
+          Object {
+            "key": 37,
+          },
+          Object {
+            "key": 38,
+          },
+          Object {
+            "key": 39,
+          },
+          Object {
+            "key": 40,
+          },
+          Object {
+            "key": 41,
+          },
+          Object {
+            "key": 42,
+          },
+          Object {
+            "key": 43,
+          },
+          Object {
+            "key": 44,
+          },
+          Object {
+            "key": 45,
+          },
+          Object {
+            "key": 46,
+          },
+          Object {
+            "key": 47,
+          },
+          Object {
+            "key": 48,
+          },
+          Object {
+            "key": 49,
+          },
+          Object {
+            "key": 50,
+          },
+          Object {
+            "key": 51,
+          },
+          Object {
+            "key": 52,
+          },
+          Object {
+            "key": 53,
+          },
+          Object {
+            "key": 54,
+          },
+          Object {
+            "key": 55,
+          },
+          Object {
+            "key": 56,
+          },
+          Object {
+            "key": 57,
+          },
+          Object {
+            "key": 58,
+          },
+          Object {
+            "key": 59,
+          },
+          Object {
+            "key": 60,
+          },
+          Object {
+            "key": 61,
+          },
+          Object {
+            "key": 62,
+          },
+          Object {
+            "key": 63,
+          },
+          Object {
+            "key": 64,
+          },
+          Object {
+            "key": 65,
+          },
+          Object {
+            "key": 66,
+          },
+          Object {
+            "key": 67,
+          },
+          Object {
+            "key": 68,
+          },
+          Object {
+            "key": 69,
+          },
+        ],
+        "ProjectionExpression": "projectionExpressionValue",
+      },
+      "anotherTableName1": Object {
+        "AttributesToGet": Array [
+          "attributeId",
+        ],
+        "ConsistentRead": true,
+        "ExpressionAttributeNames": Object {},
+        "Keys": Array [
+          Object {
+            "key": 0,
+          },
+          Object {
+            "key": 1,
+          },
+          Object {
+            "key": 2,
+          },
+          Object {
+            "key": 3,
+          },
+          Object {
+            "key": 4,
+          },
+          Object {
+            "key": 5,
+          },
+          Object {
+            "key": 6,
+          },
+          Object {
+            "key": 7,
+          },
+          Object {
+            "key": 8,
+          },
+          Object {
+            "key": 9,
+          },
+        ],
+        "ProjectionExpression": "projectionExpressionValue",
+      },
+      "tableName": Object {
+        "AttributesToGet": Array [
+          "attributeId",
+        ],
+        "ConsistentRead": true,
+        "ExpressionAttributeNames": Object {},
+        "Keys": Array [
+          Object {
+            "key": 0,
+          },
+          Object {
+            "key": 1,
+          },
+          Object {
+            "key": 2,
+          },
+          Object {
+            "key": 3,
+          },
+          Object {
+            "key": 4,
+          },
+          Object {
+            "key": 5,
+          },
+          Object {
+            "key": 6,
+          },
+          Object {
+            "key": 7,
+          },
+          Object {
+            "key": 8,
+          },
+          Object {
+            "key": 9,
+          },
+          Object {
+            "key": 10,
+          },
+          Object {
+            "key": 11,
+          },
+          Object {
+            "key": 12,
+          },
+          Object {
+            "key": 13,
+          },
+          Object {
+            "key": 14,
+          },
+          Object {
+            "key": 15,
+          },
+          Object {
+            "key": 16,
+          },
+          Object {
+            "key": 17,
+          },
+          Object {
+            "key": 18,
+          },
+          Object {
+            "key": 19,
+          },
+        ],
+        "ProjectionExpression": "projectionExpressionValue",
+      },
+    },
+    "ReturnConsumedCapacity": "returnConsumedCapacityValue",
+  },
+  Object {
+    "RequestItems": Object {
+      "anotherTableName1": Object {
+        "AttributesToGet": Array [
+          "attributeId",
+        ],
+        "ConsistentRead": true,
+        "ExpressionAttributeNames": Object {},
+        "Keys": Array [
+          Object {
+            "key": 10,
+          },
+          Object {
+            "key": 11,
+          },
+          Object {
+            "key": 12,
+          },
+          Object {
+            "key": 13,
+          },
+          Object {
+            "key": 14,
+          },
+          Object {
+            "key": 15,
+          },
+          Object {
+            "key": 16,
+          },
+          Object {
+            "key": 17,
+          },
+          Object {
+            "key": 18,
+          },
+          Object {
+            "key": 19,
+          },
+          Object {
+            "key": 20,
+          },
+          Object {
+            "key": 21,
+          },
+          Object {
+            "key": 22,
+          },
+          Object {
+            "key": 23,
+          },
+          Object {
+            "key": 24,
+          },
+          Object {
+            "key": 25,
+          },
+          Object {
+            "key": 26,
+          },
+          Object {
+            "key": 27,
+          },
+          Object {
+            "key": 28,
+          },
+          Object {
+            "key": 29,
+          },
+          Object {
+            "key": 30,
+          },
+          Object {
+            "key": 31,
+          },
+          Object {
+            "key": 32,
+          },
+          Object {
+            "key": 33,
+          },
+          Object {
+            "key": 34,
+          },
+          Object {
+            "key": 35,
+          },
+          Object {
+            "key": 36,
+          },
+          Object {
+            "key": 37,
+          },
+          Object {
+            "key": 38,
+          },
+          Object {
+            "key": 39,
+          },
+        ],
+        "ProjectionExpression": "projectionExpressionValue",
+      },
+    },
+    "ReturnConsumedCapacity": "returnConsumedCapacityValue",
+  },
+]
+`;
+
 exports[`safeBatchGetItem Returns correctly the result when under 100 1`] = `
+Object {
+  "ConsumedCapacity": Array [],
+  "Responses": Object {
+    "tableName": Array [
+      Object {
+        "key": 1,
+      },
+      Object {
+        "key": 2,
+      },
+    ],
+  },
+  "UnprocessedKeys": Object {},
+}
+`;
+
+exports[`safeBatchGetItem Works correctly with many tables when over 100 1`] = `
+Array [
+  Object {
+    "RequestItems": Object {
+      "tableName": Object {
+        "AttributesToGet": Array [
+          "attributeId",
+        ],
+        "ConsistentRead": true,
+        "ExpressionAttributeNames": Object {},
+        "Keys": Array [
+          Object {
+            "key": 0,
+          },
+          Object {
+            "key": 1,
+          },
+          Object {
+            "key": 2,
+          },
+          Object {
+            "key": 3,
+          },
+          Object {
+            "key": 4,
+          },
+          Object {
+            "key": 5,
+          },
+          Object {
+            "key": 6,
+          },
+          Object {
+            "key": 7,
+          },
+          Object {
+            "key": 8,
+          },
+          Object {
+            "key": 9,
+          },
+          Object {
+            "key": 10,
+          },
+          Object {
+            "key": 11,
+          },
+          Object {
+            "key": 12,
+          },
+          Object {
+            "key": 13,
+          },
+          Object {
+            "key": 14,
+          },
+          Object {
+            "key": 15,
+          },
+          Object {
+            "key": 16,
+          },
+          Object {
+            "key": 17,
+          },
+          Object {
+            "key": 18,
+          },
+          Object {
+            "key": 19,
+          },
+          Object {
+            "key": 20,
+          },
+          Object {
+            "key": 21,
+          },
+          Object {
+            "key": 22,
+          },
+          Object {
+            "key": 23,
+          },
+          Object {
+            "key": 24,
+          },
+          Object {
+            "key": 25,
+          },
+          Object {
+            "key": 26,
+          },
+          Object {
+            "key": 27,
+          },
+          Object {
+            "key": 28,
+          },
+          Object {
+            "key": 29,
+          },
+          Object {
+            "key": 30,
+          },
+          Object {
+            "key": 31,
+          },
+          Object {
+            "key": 32,
+          },
+          Object {
+            "key": 33,
+          },
+          Object {
+            "key": 34,
+          },
+          Object {
+            "key": 35,
+          },
+          Object {
+            "key": 36,
+          },
+          Object {
+            "key": 37,
+          },
+          Object {
+            "key": 38,
+          },
+          Object {
+            "key": 39,
+          },
+          Object {
+            "key": 40,
+          },
+          Object {
+            "key": 41,
+          },
+          Object {
+            "key": 42,
+          },
+          Object {
+            "key": 43,
+          },
+          Object {
+            "key": 44,
+          },
+          Object {
+            "key": 45,
+          },
+          Object {
+            "key": 46,
+          },
+          Object {
+            "key": 47,
+          },
+          Object {
+            "key": 48,
+          },
+          Object {
+            "key": 49,
+          },
+          Object {
+            "key": 50,
+          },
+          Object {
+            "key": 51,
+          },
+          Object {
+            "key": 52,
+          },
+          Object {
+            "key": 53,
+          },
+          Object {
+            "key": 54,
+          },
+          Object {
+            "key": 55,
+          },
+          Object {
+            "key": 56,
+          },
+          Object {
+            "key": 57,
+          },
+          Object {
+            "key": 58,
+          },
+          Object {
+            "key": 59,
+          },
+          Object {
+            "key": 60,
+          },
+          Object {
+            "key": 61,
+          },
+          Object {
+            "key": 62,
+          },
+          Object {
+            "key": 63,
+          },
+          Object {
+            "key": 64,
+          },
+          Object {
+            "key": 65,
+          },
+          Object {
+            "key": 66,
+          },
+          Object {
+            "key": 67,
+          },
+          Object {
+            "key": 68,
+          },
+          Object {
+            "key": 69,
+          },
+          Object {
+            "key": 70,
+          },
+          Object {
+            "key": 71,
+          },
+          Object {
+            "key": 72,
+          },
+          Object {
+            "key": 73,
+          },
+          Object {
+            "key": 74,
+          },
+          Object {
+            "key": 75,
+          },
+          Object {
+            "key": 76,
+          },
+          Object {
+            "key": 77,
+          },
+          Object {
+            "key": 78,
+          },
+          Object {
+            "key": 79,
+          },
+          Object {
+            "key": 80,
+          },
+          Object {
+            "key": 81,
+          },
+          Object {
+            "key": 82,
+          },
+          Object {
+            "key": 83,
+          },
+          Object {
+            "key": 84,
+          },
+          Object {
+            "key": 85,
+          },
+          Object {
+            "key": 86,
+          },
+          Object {
+            "key": 87,
+          },
+          Object {
+            "key": 88,
+          },
+          Object {
+            "key": 89,
+          },
+          Object {
+            "key": 90,
+          },
+          Object {
+            "key": 91,
+          },
+          Object {
+            "key": 92,
+          },
+          Object {
+            "key": 93,
+          },
+          Object {
+            "key": 94,
+          },
+          Object {
+            "key": 95,
+          },
+          Object {
+            "key": 96,
+          },
+          Object {
+            "key": 97,
+          },
+          Object {
+            "key": 98,
+          },
+          Object {
+            "key": 99,
+          },
+        ],
+        "ProjectionExpression": "projectionExpressionValue",
+      },
+    },
+    "ReturnConsumedCapacity": "returnConsumedCapacityValue",
+  },
+  Object {
+    "RequestItems": Object {
+      "anotherTableName": Object {
+        "AttributesToGet": Array [
+          "attributeId",
+        ],
+        "ConsistentRead": true,
+        "ExpressionAttributeNames": Object {},
+        "Keys": Array [
+          Object {
+            "key": 0,
+          },
+          Object {
+            "key": 1,
+          },
+          Object {
+            "key": 2,
+          },
+          Object {
+            "key": 3,
+          },
+          Object {
+            "key": 4,
+          },
+          Object {
+            "key": 5,
+          },
+          Object {
+            "key": 6,
+          },
+          Object {
+            "key": 7,
+          },
+          Object {
+            "key": 8,
+          },
+          Object {
+            "key": 9,
+          },
+          Object {
+            "key": 10,
+          },
+          Object {
+            "key": 11,
+          },
+          Object {
+            "key": 12,
+          },
+          Object {
+            "key": 13,
+          },
+          Object {
+            "key": 14,
+          },
+          Object {
+            "key": 15,
+          },
+          Object {
+            "key": 16,
+          },
+          Object {
+            "key": 17,
+          },
+          Object {
+            "key": 18,
+          },
+          Object {
+            "key": 19,
+          },
+          Object {
+            "key": 20,
+          },
+          Object {
+            "key": 21,
+          },
+          Object {
+            "key": 22,
+          },
+          Object {
+            "key": 23,
+          },
+          Object {
+            "key": 24,
+          },
+          Object {
+            "key": 25,
+          },
+          Object {
+            "key": 26,
+          },
+          Object {
+            "key": 27,
+          },
+          Object {
+            "key": 28,
+          },
+          Object {
+            "key": 29,
+          },
+          Object {
+            "key": 30,
+          },
+          Object {
+            "key": 31,
+          },
+          Object {
+            "key": 32,
+          },
+          Object {
+            "key": 33,
+          },
+          Object {
+            "key": 34,
+          },
+          Object {
+            "key": 35,
+          },
+          Object {
+            "key": 36,
+          },
+          Object {
+            "key": 37,
+          },
+          Object {
+            "key": 38,
+          },
+          Object {
+            "key": 39,
+          },
+          Object {
+            "key": 40,
+          },
+          Object {
+            "key": 41,
+          },
+          Object {
+            "key": 42,
+          },
+          Object {
+            "key": 43,
+          },
+          Object {
+            "key": 44,
+          },
+          Object {
+            "key": 45,
+          },
+          Object {
+            "key": 46,
+          },
+          Object {
+            "key": 47,
+          },
+          Object {
+            "key": 48,
+          },
+          Object {
+            "key": 49,
+          },
+          Object {
+            "key": 50,
+          },
+          Object {
+            "key": 51,
+          },
+          Object {
+            "key": 52,
+          },
+          Object {
+            "key": 53,
+          },
+          Object {
+            "key": 54,
+          },
+          Object {
+            "key": 55,
+          },
+          Object {
+            "key": 56,
+          },
+          Object {
+            "key": 57,
+          },
+          Object {
+            "key": 58,
+          },
+          Object {
+            "key": 59,
+          },
+          Object {
+            "key": 60,
+          },
+          Object {
+            "key": 61,
+          },
+          Object {
+            "key": 62,
+          },
+          Object {
+            "key": 63,
+          },
+          Object {
+            "key": 64,
+          },
+          Object {
+            "key": 65,
+          },
+          Object {
+            "key": 66,
+          },
+          Object {
+            "key": 67,
+          },
+          Object {
+            "key": 68,
+          },
+          Object {
+            "key": 69,
+          },
+          Object {
+            "key": 70,
+          },
+          Object {
+            "key": 71,
+          },
+          Object {
+            "key": 72,
+          },
+          Object {
+            "key": 73,
+          },
+          Object {
+            "key": 74,
+          },
+          Object {
+            "key": 75,
+          },
+          Object {
+            "key": 76,
+          },
+          Object {
+            "key": 77,
+          },
+          Object {
+            "key": 78,
+          },
+          Object {
+            "key": 79,
+          },
+          Object {
+            "key": 80,
+          },
+          Object {
+            "key": 81,
+          },
+          Object {
+            "key": 82,
+          },
+          Object {
+            "key": 83,
+          },
+          Object {
+            "key": 84,
+          },
+          Object {
+            "key": 85,
+          },
+          Object {
+            "key": 86,
+          },
+          Object {
+            "key": 87,
+          },
+          Object {
+            "key": 88,
+          },
+          Object {
+            "key": 89,
+          },
+          Object {
+            "key": 90,
+          },
+          Object {
+            "key": 91,
+          },
+          Object {
+            "key": 92,
+          },
+          Object {
+            "key": 93,
+          },
+          Object {
+            "key": 94,
+          },
+          Object {
+            "key": 95,
+          },
+          Object {
+            "key": 96,
+          },
+          Object {
+            "key": 97,
+          },
+          Object {
+            "key": 98,
+          },
+          Object {
+            "key": 99,
+          },
+        ],
+        "ProjectionExpression": "projectionExpressionValue",
+      },
+    },
+    "ReturnConsumedCapacity": "returnConsumedCapacityValue",
+  },
+  Object {
+    "RequestItems": Object {
+      "tableName": Object {
+        "AttributesToGet": Array [
+          "attributeId",
+        ],
+        "ConsistentRead": true,
+        "ExpressionAttributeNames": Object {},
+        "Keys": Array [
+          Object {
+            "key": 100,
+          },
+          Object {
+            "key": 101,
+          },
+          Object {
+            "key": 102,
+          },
+          Object {
+            "key": 103,
+          },
+          Object {
+            "key": 104,
+          },
+          Object {
+            "key": 105,
+          },
+          Object {
+            "key": 106,
+          },
+          Object {
+            "key": 107,
+          },
+          Object {
+            "key": 108,
+          },
+          Object {
+            "key": 109,
+          },
+          Object {
+            "key": 110,
+          },
+          Object {
+            "key": 111,
+          },
+          Object {
+            "key": 112,
+          },
+          Object {
+            "key": 113,
+          },
+          Object {
+            "key": 114,
+          },
+          Object {
+            "key": 115,
+          },
+          Object {
+            "key": 116,
+          },
+          Object {
+            "key": 117,
+          },
+          Object {
+            "key": 118,
+          },
+          Object {
+            "key": 119,
+          },
+          Object {
+            "key": 120,
+          },
+          Object {
+            "key": 121,
+          },
+          Object {
+            "key": 122,
+          },
+          Object {
+            "key": 123,
+          },
+          Object {
+            "key": 124,
+          },
+          Object {
+            "key": 125,
+          },
+          Object {
+            "key": 126,
+          },
+          Object {
+            "key": 127,
+          },
+          Object {
+            "key": 128,
+          },
+          Object {
+            "key": 129,
+          },
+          Object {
+            "key": 130,
+          },
+          Object {
+            "key": 131,
+          },
+          Object {
+            "key": 132,
+          },
+          Object {
+            "key": 133,
+          },
+          Object {
+            "key": 134,
+          },
+          Object {
+            "key": 135,
+          },
+          Object {
+            "key": 136,
+          },
+          Object {
+            "key": 137,
+          },
+          Object {
+            "key": 138,
+          },
+          Object {
+            "key": 139,
+          },
+          Object {
+            "key": 140,
+          },
+          Object {
+            "key": 141,
+          },
+          Object {
+            "key": 142,
+          },
+          Object {
+            "key": 143,
+          },
+          Object {
+            "key": 144,
+          },
+          Object {
+            "key": 145,
+          },
+          Object {
+            "key": 146,
+          },
+          Object {
+            "key": 147,
+          },
+          Object {
+            "key": 148,
+          },
+          Object {
+            "key": 149,
+          },
+          Object {
+            "key": 150,
+          },
+          Object {
+            "key": 151,
+          },
+          Object {
+            "key": 152,
+          },
+          Object {
+            "key": 153,
+          },
+          Object {
+            "key": 154,
+          },
+          Object {
+            "key": 155,
+          },
+          Object {
+            "key": 156,
+          },
+          Object {
+            "key": 157,
+          },
+          Object {
+            "key": 158,
+          },
+          Object {
+            "key": 159,
+          },
+          Object {
+            "key": 160,
+          },
+          Object {
+            "key": 161,
+          },
+          Object {
+            "key": 162,
+          },
+          Object {
+            "key": 163,
+          },
+          Object {
+            "key": 164,
+          },
+          Object {
+            "key": 165,
+          },
+          Object {
+            "key": 166,
+          },
+          Object {
+            "key": 167,
+          },
+          Object {
+            "key": 168,
+          },
+          Object {
+            "key": 169,
+          },
+          Object {
+            "key": 170,
+          },
+          Object {
+            "key": 171,
+          },
+          Object {
+            "key": 172,
+          },
+          Object {
+            "key": 173,
+          },
+          Object {
+            "key": 174,
+          },
+          Object {
+            "key": 175,
+          },
+          Object {
+            "key": 176,
+          },
+          Object {
+            "key": 177,
+          },
+          Object {
+            "key": 178,
+          },
+          Object {
+            "key": 179,
+          },
+          Object {
+            "key": 180,
+          },
+          Object {
+            "key": 181,
+          },
+          Object {
+            "key": 182,
+          },
+          Object {
+            "key": 183,
+          },
+          Object {
+            "key": 184,
+          },
+          Object {
+            "key": 185,
+          },
+          Object {
+            "key": 186,
+          },
+          Object {
+            "key": 187,
+          },
+          Object {
+            "key": 188,
+          },
+          Object {
+            "key": 189,
+          },
+          Object {
+            "key": 190,
+          },
+          Object {
+            "key": 191,
+          },
+          Object {
+            "key": 192,
+          },
+          Object {
+            "key": 193,
+          },
+          Object {
+            "key": 194,
+          },
+          Object {
+            "key": 195,
+          },
+          Object {
+            "key": 196,
+          },
+          Object {
+            "key": 197,
+          },
+          Object {
+            "key": 198,
+          },
+          Object {
+            "key": 199,
+          },
+        ],
+        "ProjectionExpression": "projectionExpressionValue",
+      },
+    },
+    "ReturnConsumedCapacity": "returnConsumedCapacityValue",
+  },
+  Object {
+    "RequestItems": Object {
+      "anotherTableName": Object {
+        "AttributesToGet": Array [
+          "attributeId",
+        ],
+        "ConsistentRead": true,
+        "ExpressionAttributeNames": Object {},
+        "Keys": Array [
+          Object {
+            "key": 100,
+          },
+          Object {
+            "key": 101,
+          },
+          Object {
+            "key": 102,
+          },
+          Object {
+            "key": 103,
+          },
+          Object {
+            "key": 104,
+          },
+          Object {
+            "key": 105,
+          },
+          Object {
+            "key": 106,
+          },
+          Object {
+            "key": 107,
+          },
+          Object {
+            "key": 108,
+          },
+          Object {
+            "key": 109,
+          },
+          Object {
+            "key": 110,
+          },
+          Object {
+            "key": 111,
+          },
+          Object {
+            "key": 112,
+          },
+          Object {
+            "key": 113,
+          },
+          Object {
+            "key": 114,
+          },
+          Object {
+            "key": 115,
+          },
+          Object {
+            "key": 116,
+          },
+          Object {
+            "key": 117,
+          },
+          Object {
+            "key": 118,
+          },
+          Object {
+            "key": 119,
+          },
+          Object {
+            "key": 120,
+          },
+          Object {
+            "key": 121,
+          },
+          Object {
+            "key": 122,
+          },
+          Object {
+            "key": 123,
+          },
+          Object {
+            "key": 124,
+          },
+          Object {
+            "key": 125,
+          },
+          Object {
+            "key": 126,
+          },
+          Object {
+            "key": 127,
+          },
+          Object {
+            "key": 128,
+          },
+          Object {
+            "key": 129,
+          },
+          Object {
+            "key": 130,
+          },
+          Object {
+            "key": 131,
+          },
+          Object {
+            "key": 132,
+          },
+          Object {
+            "key": 133,
+          },
+          Object {
+            "key": 134,
+          },
+          Object {
+            "key": 135,
+          },
+          Object {
+            "key": 136,
+          },
+          Object {
+            "key": 137,
+          },
+          Object {
+            "key": 138,
+          },
+          Object {
+            "key": 139,
+          },
+          Object {
+            "key": 140,
+          },
+          Object {
+            "key": 141,
+          },
+          Object {
+            "key": 142,
+          },
+          Object {
+            "key": 143,
+          },
+          Object {
+            "key": 144,
+          },
+          Object {
+            "key": 145,
+          },
+          Object {
+            "key": 146,
+          },
+          Object {
+            "key": 147,
+          },
+          Object {
+            "key": 148,
+          },
+          Object {
+            "key": 149,
+          },
+        ],
+        "ProjectionExpression": "projectionExpressionValue",
+      },
+    },
+    "ReturnConsumedCapacity": "returnConsumedCapacityValue",
+  },
+]
+`;
+
+exports[`safeBatchGetItem Works correctly with many tables when over 100 2`] = `
+Object {
+  "ConsumedCapacity": Array [],
+  "Responses": Object {
+    "tableName": Array [
+      Object {
+        "key": 1,
+      },
+      Object {
+        "key": 2,
+      },
+      Object {
+        "key": 1,
+      },
+      Object {
+        "key": 2,
+      },
+      Object {
+        "key": 1,
+      },
+      Object {
+        "key": 2,
+      },
+      Object {
+        "key": 1,
+      },
+      Object {
+        "key": 2,
+      },
+    ],
+  },
+  "UnprocessedKeys": Object {},
+}
+`;
+
+exports[`safeBatchGetItem Works correctly with many tables when under 100 1`] = `
+Array [
+  Object {
+    "RequestItems": Object {
+      "anotherTableName": Object {
+        "AttributesToGet": Array [
+          "attributeId",
+        ],
+        "ConsistentRead": true,
+        "ExpressionAttributeNames": Object {},
+        "Keys": Array [
+          Object {
+            "key": 0,
+          },
+          Object {
+            "key": 1,
+          },
+          Object {
+            "key": 2,
+          },
+          Object {
+            "key": 3,
+          },
+          Object {
+            "key": 4,
+          },
+          Object {
+            "key": 5,
+          },
+          Object {
+            "key": 6,
+          },
+          Object {
+            "key": 7,
+          },
+          Object {
+            "key": 8,
+          },
+          Object {
+            "key": 9,
+          },
+          Object {
+            "key": 10,
+          },
+          Object {
+            "key": 11,
+          },
+          Object {
+            "key": 12,
+          },
+          Object {
+            "key": 13,
+          },
+          Object {
+            "key": 14,
+          },
+          Object {
+            "key": 15,
+          },
+          Object {
+            "key": 16,
+          },
+          Object {
+            "key": 17,
+          },
+          Object {
+            "key": 18,
+          },
+          Object {
+            "key": 19,
+          },
+          Object {
+            "key": 20,
+          },
+          Object {
+            "key": 21,
+          },
+          Object {
+            "key": 22,
+          },
+          Object {
+            "key": 23,
+          },
+          Object {
+            "key": 24,
+          },
+          Object {
+            "key": 25,
+          },
+          Object {
+            "key": 26,
+          },
+          Object {
+            "key": 27,
+          },
+          Object {
+            "key": 28,
+          },
+          Object {
+            "key": 29,
+          },
+        ],
+        "ProjectionExpression": "projectionExpressionValue",
+      },
+      "anotherTableName1": Object {
+        "AttributesToGet": Array [
+          "attributeId",
+        ],
+        "ConsistentRead": true,
+        "ExpressionAttributeNames": Object {},
+        "Keys": Array [
+          Object {
+            "key": 0,
+          },
+          Object {
+            "key": 1,
+          },
+          Object {
+            "key": 2,
+          },
+          Object {
+            "key": 3,
+          },
+          Object {
+            "key": 4,
+          },
+          Object {
+            "key": 5,
+          },
+          Object {
+            "key": 6,
+          },
+          Object {
+            "key": 7,
+          },
+          Object {
+            "key": 8,
+          },
+          Object {
+            "key": 9,
+          },
+          Object {
+            "key": 10,
+          },
+          Object {
+            "key": 11,
+          },
+          Object {
+            "key": 12,
+          },
+          Object {
+            "key": 13,
+          },
+          Object {
+            "key": 14,
+          },
+          Object {
+            "key": 15,
+          },
+          Object {
+            "key": 16,
+          },
+          Object {
+            "key": 17,
+          },
+          Object {
+            "key": 18,
+          },
+          Object {
+            "key": 19,
+          },
+          Object {
+            "key": 20,
+          },
+          Object {
+            "key": 21,
+          },
+          Object {
+            "key": 22,
+          },
+          Object {
+            "key": 23,
+          },
+          Object {
+            "key": 24,
+          },
+          Object {
+            "key": 25,
+          },
+          Object {
+            "key": 26,
+          },
+          Object {
+            "key": 27,
+          },
+          Object {
+            "key": 28,
+          },
+          Object {
+            "key": 29,
+          },
+          Object {
+            "key": 30,
+          },
+          Object {
+            "key": 31,
+          },
+          Object {
+            "key": 32,
+          },
+          Object {
+            "key": 33,
+          },
+          Object {
+            "key": 34,
+          },
+          Object {
+            "key": 35,
+          },
+          Object {
+            "key": 36,
+          },
+          Object {
+            "key": 37,
+          },
+          Object {
+            "key": 38,
+          },
+          Object {
+            "key": 39,
+          },
+        ],
+        "ProjectionExpression": "projectionExpressionValue",
+      },
+      "tableName": Object {
+        "AttributesToGet": Array [
+          "attributeId",
+        ],
+        "ConsistentRead": true,
+        "ExpressionAttributeNames": Object {},
+        "Keys": Array [
+          Object {
+            "key": 0,
+          },
+          Object {
+            "key": 1,
+          },
+          Object {
+            "key": 2,
+          },
+          Object {
+            "key": 3,
+          },
+          Object {
+            "key": 4,
+          },
+          Object {
+            "key": 5,
+          },
+          Object {
+            "key": 6,
+          },
+          Object {
+            "key": 7,
+          },
+          Object {
+            "key": 8,
+          },
+          Object {
+            "key": 9,
+          },
+          Object {
+            "key": 10,
+          },
+          Object {
+            "key": 11,
+          },
+          Object {
+            "key": 12,
+          },
+          Object {
+            "key": 13,
+          },
+          Object {
+            "key": 14,
+          },
+          Object {
+            "key": 15,
+          },
+          Object {
+            "key": 16,
+          },
+          Object {
+            "key": 17,
+          },
+          Object {
+            "key": 18,
+          },
+          Object {
+            "key": 19,
+          },
+        ],
+        "ProjectionExpression": "projectionExpressionValue",
+      },
+    },
+    "ReturnConsumedCapacity": "returnConsumedCapacityValue",
+  },
+]
+`;
+
+exports[`safeBatchGetItem Works correctly with many tables when under 100 2`] = `
 Object {
   "ConsumedCapacity": Array [],
   "Responses": Object {

--- a/tests/utils/__snapshots__/safeBatchGetItem.test.js.snap
+++ b/tests/utils/__snapshots__/safeBatchGetItem.test.js.snap
@@ -1600,41 +1600,6 @@ Array [
 ]
 `;
 
-exports[`safeBatchGetItem Works correctly with many tables when over 100 2`] = `
-Object {
-  "ConsumedCapacity": Array [],
-  "Responses": Object {
-    "tableName": Array [
-      Object {
-        "key": 1,
-      },
-      Object {
-        "key": 2,
-      },
-      Object {
-        "key": 1,
-      },
-      Object {
-        "key": 2,
-      },
-      Object {
-        "key": 1,
-      },
-      Object {
-        "key": 2,
-      },
-      Object {
-        "key": 1,
-      },
-      Object {
-        "key": 2,
-      },
-    ],
-  },
-  "UnprocessedKeys": Object {},
-}
-`;
-
 exports[`safeBatchGetItem Works correctly with many tables when under 100 1`] = `
 Array [
   Object {
@@ -1943,23 +1908,6 @@ Array [
     "ReturnConsumedCapacity": "returnConsumedCapacityValue",
   },
 ]
-`;
-
-exports[`safeBatchGetItem Works correctly with many tables when under 100 2`] = `
-Object {
-  "ConsumedCapacity": Array [],
-  "Responses": Object {
-    "tableName": Array [
-      Object {
-        "key": 1,
-      },
-      Object {
-        "key": 2,
-      },
-    ],
-  },
-  "UnprocessedKeys": Object {},
-}
 `;
 
 exports[`safeBatchGetItem splits the params if they exceed 100 keys 1`] = `

--- a/tests/utils/safeBatchGetItem.test.js
+++ b/tests/utils/safeBatchGetItem.test.js
@@ -1,0 +1,104 @@
+const _ = require('lodash');
+
+const safeBatchGetItem = require('../../src/utils/safeBatchGetItem');
+
+const generateTestParams = (amountOfKeys) => (
+  {
+    RequestItems: {
+      tableName: {
+        AttributesToGet: ['attributeId'],
+        ConsistentRead: true,
+        ExpressionAttributeNames: {},
+        Keys: _.range(amountOfKeys).map((index) => ({ key: index })),
+        ProjectionExpression: 'projectionExpressionValue',
+      },
+    },
+    ReturnConsumedCapacity: 'returnConsumedCapacityValue',
+  }
+);
+
+let allParams = [];
+let lastBatchGetItemParams;
+
+const mockDynamodb = (response = {}) => {
+  allParams = [];
+  lastBatchGetItemParams = undefined;
+
+  return {
+    batchGetItem: (params) => ({
+      promise: () => {
+        lastBatchGetItemParams = params;
+        allParams.push(params);
+        return Promise.resolve(response);
+      },
+    }),
+  };
+};
+
+describe('safeBatchGetItem', () => {
+  it('uses the same params if they don\'t exceed 100 keys', async () => {
+    const dynamodb = mockDynamodb();
+    const params = generateTestParams(50);
+
+    await safeBatchGetItem(dynamodb, params);
+
+    // Generates the same params as received
+    expect(lastBatchGetItemParams).toEqual(params);
+  });
+
+  it('splits the params if they exceed 100 keys', async () => {
+    const dynamodb = mockDynamodb();
+    const params = generateTestParams(150);
+
+    await safeBatchGetItem(dynamodb, params);
+
+    // Doesn't generate the same params as received
+    expect(lastBatchGetItemParams).not.toEqual(params);
+
+    // Was split into 2 calls
+    expect(allParams.length).toEqual(2);
+
+    // Keys were split correctly
+    expect(allParams).toMatchSnapshot();
+  });
+
+  it('Returns correctly the result when under 100', async () => {
+    const resultToSingleCall = {
+      ConsumedCapacity: [],
+      Responses: {
+        tableName: [
+          { key: 1 },
+          { key: 2 },
+        ],
+      },
+      UnprocessedKeys: {},
+    };
+
+    const dynamodb = mockDynamodb(resultToSingleCall);
+    const params = generateTestParams(30);
+
+    const result = await safeBatchGetItem(dynamodb, params);
+
+    expect(result).toMatchSnapshot();
+  });
+
+  it('Combines correctly the result when over 100', async () => {
+    const resultToSingleCall = {
+      ConsumedCapacity: [],
+      Responses: {
+        tableName: [
+          { key: 1 },
+          { key: 2 },
+        ],
+      },
+      UnprocessedKeys: {},
+    };
+
+    const dynamodb = mockDynamodb(resultToSingleCall);
+    const params = generateTestParams(200);
+
+    const result = await safeBatchGetItem(dynamodb, params);
+
+    expect(result).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
# Background
#### Link to issue 
https://biomage.atlassian.net/browse/BIOMAGE-1027

#### Link to staging deployment URL 
https://ui-martinfosco-api138.scp-staging.biomage.net/

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [x] Unit tests written
- [x] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [x] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
