### PR TITLE
Fix X-Ray Context Missing error in HTTP requests using fetch

### DIFF
--- a/src/api/routes/gem2s.js
+++ b/src/api/routes/gem2s.js
@@ -10,14 +10,12 @@ const { expressAuthorizationMiddleware } = require('../../utils/authMiddlewares'
 module.exports = {
   'gem2s#create': [
     expressAuthorizationMiddleware,
-    (req, res, next) => {
-      createGem2SPipeline(req.params.experimentId)
-        .then((data) => {
-          const experimentService = new ExperimentService();
-          experimentService.saveGem2sHandle(req.params.experimentId, data)
-            .then(() => res.json(data));
-        })
-        .catch(next);
+    async (req, res) => {
+      const data = await createGem2SPipeline(req.params.experimentId);
+
+      const experimentService = new ExperimentService();
+      await experimentService.saveGem2sHandle(req.params.experimentId, data);
+      res.json(data);
     },
   ],
 

--- a/src/api/routes/pipelines.js
+++ b/src/api/routes/pipelines.js
@@ -10,24 +10,20 @@ const { expressAuthorizationMiddleware } = require('../../utils/authMiddlewares'
 module.exports = {
   'pipelines#get': [
     expressAuthorizationMiddleware,
-    (req, res, next) => {
+    async (req, res) => {
       // The changes to add gem2s status will be obsoleted once agi's PR is merged in
-      getBackendStatus(req.params.experimentId)
-        .then((data) => res.json(data))
-        .catch(next);
+      const data = await getBackendStatus(req.params.experimentId);
+      res.json(data);
     },
   ],
   'pipelines#create': [
-    (req, res, next) => {
+    async (req, res) => {
       const { processingConfig } = req.body;
 
-      createQCPipeline(req.params.experimentId, processingConfig || [])
-        .then((data) => {
-          const experimentService = new ExperimentService();
-          experimentService.saveQCHandle(req.params.experimentId, data)
-            .then(() => res.json(data));
-        })
-        .catch(next);
+      const data = await createQCPipeline(req.params.experimentId, processingConfig || []);
+      const experimentService = new ExperimentService();
+      await experimentService.saveQCHandle(req.params.experimentId, data);
+      res.json(data);
     },
   ],
   'pipelines#response': async (req, res) => {


### PR DESCRIPTION
# Background
#### Link to issue 
N/A

#### Link to staging deployment URL 
TBD

#### Links to any Pull Requests related to this
N/A

#### Anything else the reviewers should know about the changes here
See the discussion at: https://this-is-biomage.slack.com/archives/C015CHSUDRU/p1622626494073800

# Changes
### Code changes
Convert HTTP request handlers that use `fetch` to use `async/await` syntax to make sure X-Ray can recognize them as belonging to the request. This may be a bug in the AWS X-Ray Node.js middleware.

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [x] Unit tests written
- [x] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [x] Relevant Github READMEs updated
- [x] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
