### PR TITLE
Not store workers clustering errors

### DIFF
--- a/src/api/route-services/work-response.js
+++ b/src/api/route-services/work-response.js
@@ -128,7 +128,10 @@ class WorkResponseService {
       logger.log('Sending work response to all clients subscribed to experiment', experimentId);
       this.io.sockets.emit(`ExperimentUpdates-${experimentId}`, response);
 
-      await persistUpdates(experimentId, responseForClient);
+      if (!responseForClient.response.error) {
+        await persistUpdates(experimentId, responseForClient);
+      }
+
       return;
     }
 


### PR DESCRIPTION
# Background
#### Link to issue 

#### Link to staging deployment URL 
https://ui-martinfosco-api164.scp-staging.biomage.net/

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here
Before this fix, if the worker failed on clustering request once this response was stored and new clustering requests couldn't be sent (since the cell sets that were returned were actually a stacktrace of the error).

With this fix we just avoid persisting the response if it shows up as an error.

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [x] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [x] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
