### PR TITLE
[BIOMAGE-1066] pointing pipeline config to biomage-ltd again

### DIFF
--- a/src/config/default-config.js
+++ b/src/config/default-config.js
@@ -115,7 +115,7 @@ if (config.clusterEnv === 'development') {
 
   // remove this line when the new gem2s-endpoint is merged and thus the production/pipeline.yaml is
   // updated to new name pipeline-runner
-  config.pipelineInstanceConfigUrl = 'https://raw.githubusercontent.com/kafkasl/iac/master/releases/production/pipeline.yaml';
+  config.pipelineInstanceConfigUrl = 'https://raw.githubusercontent.com/biomage-ltd/iac/master/releases/production/pipeline.yaml';
   config.corsOriginUrl = 'http://localhost:5000';
   config.adminArn = '70c213d4-e7b6-4920-aefb-706ce8606ee2';
 }

--- a/src/config/test-config.js
+++ b/src/config/test-config.js
@@ -15,8 +15,7 @@ module.exports = {
   workerNamespace: 'worker-test-namespace',
   pipelineNamespace: 'pipeline-test-namespace',
   workerInstanceConfigUrl: 'https://raw.githubusercontent.com/biomage-ltd/iac/master/releases/production/worker.yaml',
-  // pipelineInstanceConfigUrl: 'https://raw.githubusercontent.com/biomage-ltd/iac/master/releases/production/pipeline.yaml',
-  pipelineInstanceConfigUrl: 'https://raw.githubusercontent.com/kafkasl/iac/master/releases/production/pipeline.yaml',
+  pipelineInstanceConfigUrl: 'https://raw.githubusercontent.com/biomage-ltd/iac/master/releases/production/pipeline.yaml',
   api: {
     prefix: '/',
   },


### PR DESCRIPTION
# Background
#### Link to issue 

https://biomage.atlassian.net/browse/BIOMAGE-1066

# Changes
### Code changes

While the new pipeline definition wasn't merged into production (with the release) the pipeline config (for local development) was taken from my forked iac repo. Now that config has been merged so it can be safely pointed to it.

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
