### PR TITLE
Move defaultFilterSettings and missing per sample config additions to the pipeline

### DIFF
--- a/src/api/route-services/gem2s.js
+++ b/src/api/route-services/gem2s.js
@@ -19,61 +19,6 @@ const ExperimentService = require('./experiment');
 const ProjectService = require('./projects');
 const SamplesService = require('./samples');
 
-const uglyTemporalFixedProcessingConfig = (processingConfig, filterName) => {
-  // This is an ugly patch we need to remove once filterName's processing config is fixed
-  // (right now we only receive default values which we no longer use)
-  const {
-    auto, enabled, filterSettings, ...samples
-  } = processingConfig.cellSizeDistribution;
-
-  const sampleIds = Object.keys(samples);
-  const defaultFilterSetting = processingConfig[filterName];
-
-  const perSampleFilterSetting = sampleIds.reduce(
-    (acum, sampleId) => {
-      // eslint-disable-next-line no-param-reassign
-      acum[sampleId] = defaultFilterSetting;
-      return acum;
-    },
-    {},
-  );
-
-  const fixedProcessingConfig = _.clone(processingConfig);
-  fixedProcessingConfig[filterName] = {
-    ...processingConfig[filterName],
-    ...perSampleFilterSetting,
-  };
-
-  return fixedProcessingConfig;
-};
-
-const addMissingPerSampleProcessingConfigValues = (processingConfig) => {
-  let fixedProcessingConfig = uglyTemporalFixedProcessingConfig(processingConfig, 'classifier');
-  fixedProcessingConfig = uglyTemporalFixedProcessingConfig(fixedProcessingConfig, 'mitochondrialContent');
-
-  return fixedProcessingConfig;
-};
-
-
-const withAutomaticSettings = (processingConfig) => {
-  const processingConfigWithAuto = _.cloneDeep(processingConfig);
-
-  // adding default config to every filter with auto option
-  Object.keys(processingConfig).forEach((step) => {
-    const currentStepSettings = processingConfig[step];
-    const sampleIds = Object.keys(currentStepSettings).filter(
-      (currentSample) => currentStepSettings[currentSample].auto,
-    );
-
-    sampleIds.forEach((sampleId) => {
-      processingConfigWithAuto[step][sampleId]
-        .defaultFilterSettings = processingConfig[step][sampleId].filterSettings;
-    });
-  });
-
-  return processingConfigWithAuto;
-};
-
 const pipelineHook = new PipelineHook();
 
 pipelineHook.register('uploadToAWS', [saveProcessingConfigFromGem2s, runQCPipeline]);
@@ -193,14 +138,6 @@ class Gem2sService {
     const {
       experimentId, taskName, item,
     } = messageForClient;
-
-    if (item) {
-      const fixedProcessingConfig = addMissingPerSampleProcessingConfigValues(
-        item.processingConfig,
-      );
-
-      item.processingConfig = withAutomaticSettings(fixedProcessingConfig);
-    }
 
     await pipelineHook.run(taskName, {
       experimentId,


### PR DESCRIPTION
# Background
#### Link to issue 

#### Link to staging deployment URL 
https://ui-martinfosco-api172-pipelin.scp-staging.biomage.net/

#### Links to any Pull Requests related to this
https://github.com/biomage-ltd/pipeline/pull/119

#### Anything else the reviewers should know about the changes here
The api was performing the changes added in the PR, there seemed to be some inconsistent behavior on the api in staging for this so I decided to move it over to the pipeline now in order to avoid potential bugs (which was already the plan in the long run).

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [x] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
