### PR TITLE
[BIOMAGE-1179] - Skip fetching ARN for copied production experiments in production

### DIFF
--- a/.github/workflows/ci-develop.yaml
+++ b/.github/workflows/ci-develop.yaml
@@ -33,11 +33,14 @@ jobs:
         npm ci
 
     - id: test
-      name: Run unit tests
+      name: Run unit tests with code coverage
       run: |-
-        npm test
+        npm run coverage
       env:
         AWS_DEFAULT_REGION: 'eu-west-1'
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v1
 
     - id: send-to-slack
       name: Send failure notification to Slack

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,16 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  range: 80..100
+  round: down
+  precision: 2
+
+  status:
+    project:                   # measuring the overall project coverage
+      default:                 
+        enabled: no           
+    patch:                    # measuring the coverage of new changes
+      default:
+        enabled: no
+  

--- a/src/api/general-services/pipeline-manage/constants.js
+++ b/src/api/general-services/pipeline-manage/constants.js
@@ -19,7 +19,7 @@ const NOT_CREATED = 'NOT_CREATED';
 // (barring unexpected errors, it happens when pulling or moving experiments across environments
 // because the ARNs are not imported)
 const EXECUTION_DOES_NOT_EXIST = 'ExecutionDoesNotExist';
-const NOT_AUTHORIZED = 'NotAuthorized';
+const ACCESS_DENIED = 'AccessDeniedException';
 
 module.exports = {
   QC_PROCESS_NAME,
@@ -32,5 +32,5 @@ module.exports = {
   SUCCEEDED,
   NOT_CREATED,
   EXECUTION_DOES_NOT_EXIST,
-  NOT_AUTHORIZED,
+  ACCESS_DENIED,
 };

--- a/src/api/general-services/pipeline-manage/constants.js
+++ b/src/api/general-services/pipeline-manage/constants.js
@@ -19,6 +19,7 @@ const NOT_CREATED = 'NOT_CREATED';
 // (barring unexpected errors, it happens when pulling or moving experiments across environments
 // because the ARNs are not imported)
 const EXECUTION_DOES_NOT_EXIST = 'ExecutionDoesNotExist';
+const NOT_AUTHORIZED = 'NotAuthorized';
 
 module.exports = {
   QC_PROCESS_NAME,
@@ -31,4 +32,5 @@ module.exports = {
   SUCCEEDED,
   NOT_CREATED,
   EXECUTION_DOES_NOT_EXIST,
+  NOT_AUTHORIZED,
 };

--- a/src/api/general-services/pipeline-status.js
+++ b/src/api/general-services/pipeline-status.js
@@ -176,10 +176,15 @@ const getPipelineStatus = async (experimentId, processName) => {
   } catch (e) {
     // if we get the execution does not exist it means we are using a pulled experiment so
     // just return a mock sucess status
-    if (config.clusterEnv === 'development' && e.code === pipelineConstants.EXECUTION_DOES_NOT_EXIST) {
-      logger.log(`Returning a mocke success ${processName}-pipeline status because ARN ${executionArn} `
-        + `does not exist and we are running in ${config.clusterEnv} so we are assuming the experiment was `
-        + ' pulled from another env.');
+    if (
+      (config.clusterEnv === 'development' && e.code === pipelineConstants.EXECUTION_DOES_NOT_EXIST)
+      || (config.clusterEnv === 'staging' && e.code === pipelineConstants.EXECUTION_DOES_NOT_EXIST)
+    ) {
+      logger.log(
+        `Returning a mocked success ${processName}-pipeline status because ARN ${executionArn} `
+          + `does not exist and we are running in ${config.clusterEnv} so we are assuming the experiment was `
+          + ' pulled from another env.',
+      );
 
       return {
         [processName]: mockedCompletedStatus[processName],

--- a/src/api/general-services/pipeline-status.js
+++ b/src/api/general-services/pipeline-status.js
@@ -178,7 +178,7 @@ const getPipelineStatus = async (experimentId, processName) => {
     // just return a mock sucess status
     if (
       (config.clusterEnv === 'development' && e.code === pipelineConstants.EXECUTION_DOES_NOT_EXIST)
-      || (config.clusterEnv === 'staging' && e.code === pipelineConstants.NOT_AUTHORIZED)
+      || (config.clusterEnv === 'staging' && e.code === pipelineConstants.ACCESS_DENIED)
     ) {
       logger.log(
         `Returning a mocked success ${processName}-pipeline status because ARN ${executionArn} `

--- a/src/api/general-services/pipeline-status.js
+++ b/src/api/general-services/pipeline-status.js
@@ -178,7 +178,7 @@ const getPipelineStatus = async (experimentId, processName) => {
     // just return a mock sucess status
     if (
       (config.clusterEnv === 'development' && e.code === pipelineConstants.EXECUTION_DOES_NOT_EXIST)
-      || (config.clusterEnv === 'staging' && e.code === pipelineConstants.EXECUTION_DOES_NOT_EXIST)
+      || (config.clusterEnv === 'staging' && e.code === pipelineConstants.NOT_AUTHORIZED)
     ) {
       logger.log(
         `Returning a mocked success ${processName}-pipeline status because ARN ${executionArn} `

--- a/src/api/route-services/gem2s.js
+++ b/src/api/route-services/gem2s.js
@@ -92,6 +92,10 @@ class Gem2sService {
     const { [GEM2S_PROCESS_NAME]: gem2sHandle } = handles;
     const { [GEM2S_PROCESS_NAME]: { status: gem2sStatus } } = statusWrapper;
 
+    console.log(gem2sStatus);
+    console.log(paramsHash);
+    console.log(gem2sHandle.paramsHash);
+
     if (gem2sStatus === SUCCEEDED) {
       return paramsHash !== gem2sHandle.paramsHash;
     }

--- a/src/api/route-services/gem2s.js
+++ b/src/api/route-services/gem2s.js
@@ -92,10 +92,6 @@ class Gem2sService {
     const { [GEM2S_PROCESS_NAME]: gem2sHandle } = handles;
     const { [GEM2S_PROCESS_NAME]: { status: gem2sStatus } } = statusWrapper;
 
-    console.log(gem2sStatus);
-    console.log(paramsHash);
-    console.log(gem2sHandle.paramsHash);
-
     if (gem2sStatus === SUCCEEDED) {
       return paramsHash !== gem2sHandle.paramsHash;
     }


### PR DESCRIPTION
# Background
#### Link to issue 

https://ui-agi-test-exp-copy.scp-staging.biomage.net/

#### Link to staging deployment URL 

in UI repo

#### Links to any Pull Requests related to this

UI : https://github.com/biomage-ltd/ui/pull/395
API : https://github.com/biomage-ltd/api/pull/178
Utils : https://github.com/biomage-ltd/biomage-utils/pull/62

#### Anything else the reviewers should know about the changes here

# Changes

- Return success status when checking for the existence of ARN in API even if the ARN doesn't exist. This happens when the experiment is copied from production.

### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [X] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
