### PR TITLE
[BIOMAGE-1211] Use a single queue and SQS Message Group IDs to deduplicate worker messages

### DIFF
--- a/src/config/test-config.js
+++ b/src/config/test-config.js
@@ -11,6 +11,7 @@ module.exports = {
   clusterEnv: 'test',
   awsRegion: 'eu-west-1',
   podName: 'test',
+  sandboxId: 'default',
   awsAccountIdPromise: getAwsAccountId(),
   workerNamespace: 'worker-test-namespace',
   pipelineNamespace: 'pipeline-test-namespace',

--- a/tests/api/event-services/work-request.test.js
+++ b/tests/api/event-services/work-request.test.js
@@ -163,7 +163,7 @@ describe('handleWorkRequest', () => {
 
   it('Triggers pagination when pagination is specified and result is cached already.', async () => {
     CacheSingleton.createMock({
-      '4029461266b19b22d8753895e51c1a8a': { // pragma: allowlist secret
+      '1030360683237eb6175194541f83d6f5': { // pragma: allowlist secret
         results: [
           {
             body: JSON.stringify({

--- a/tests/api/general-services/__snapshots__/pipeline-manage.test.js.snap
+++ b/tests/api/general-services/__snapshots__/pipeline-manage.test.js.snap
@@ -28,7 +28,7 @@ Array [
       "loggingConfiguration": Object {
         "level": "OFF",
       },
-      "name": "biomage-qc-test-af3b5c3acaa6348165d8e5e73c70d93b732bf6db",
+      "name": "biomage-qc-test-b2bacc54e31beb2bda7b4bd9b1ec33ec84eae60f",
       "roleArn": "arn:aws:iam::test-account-id:role/state-machine-role-test",
       "tags": Array [
         Object {
@@ -41,7 +41,7 @@ Array [
         },
         Object {
           "key": "sandboxId",
-          "value": undefined,
+          "value": "default",
         },
       ],
       "type": "STANDARD",
@@ -168,7 +168,7 @@ Array [
             "Path": "/apis/helm.fluxcd.io/v1/namespaces/pipeline-test-namespace/helmreleases",
             "QueryParameters": Object {
               "labelSelector": Array [
-                "type=pipeline,sandboxId=undefined,experimentId=testExperimentId",
+                "type=pipeline,sandboxId=default,experimentId=testExperimentId",
               ],
             },
           },
@@ -250,6 +250,7 @@ Array [
                 },
                 "labels": Object {
                   "experimentId": "testExperimentId",
+                  "sandboxId": "default",
                   "type": "pipeline",
                 },
                 "name": "qc-testExperimentId",
@@ -270,6 +271,7 @@ Array [
                   "experimentId": "testExperimentId",
                   "image": "MOCK_IMAGE_PATH",
                   "namespace": "pipeline-test-namespace",
+                  "sandboxId": "default",
                 },
               },
             },
@@ -376,7 +378,7 @@ Array [
       "loggingConfiguration": Object {
         "level": "OFF",
       },
-      "name": "biomage-qc-test-af3b5c3acaa6348165d8e5e73c70d93b732bf6db",
+      "name": "biomage-qc-test-b2bacc54e31beb2bda7b4bd9b1ec33ec84eae60f",
       "roleArn": "arn:aws:iam::test-account-id:role/state-machine-role-test",
       "tags": Array [
         Object {
@@ -389,7 +391,7 @@ Array [
         },
         Object {
           "key": "sandboxId",
-          "value": undefined,
+          "value": "default",
         },
       ],
       "type": "STANDARD",
@@ -404,7 +406,7 @@ Array [
     "type": "return",
     "value": Object {
       "roleArn": "arn:aws:iam::test-account-id:role/state-machine-role-test",
-      "stateMachineArn": "arn:aws:states:eu-west-1:test-account-id:stateMachine:biomage-qc-test-af3b5c3acaa6348165d8e5e73c70d93b732bf6db",
+      "stateMachineArn": "arn:aws:states:eu-west-1:test-account-id:stateMachine:biomage-qc-test-b2bacc54e31beb2bda7b4bd9b1ec33ec84eae60f",
     },
   },
 ]
@@ -416,7 +418,7 @@ Array [
     "type": "return",
     "value": Object {
       "input": "{\\"samples\\":[{\\"sampleUuid\\":\\"oneSample\\",\\"index\\":0},{\\"sampleUuid\\":\\"otherSample\\",\\"index\\":1}]}",
-      "stateMachineArn": "arn:aws:states:eu-west-1:test-account-id:stateMachine:biomage-qc-test-af3b5c3acaa6348165d8e5e73c70d93b732bf6db",
+      "stateMachineArn": "arn:aws:states:eu-west-1:test-account-id:stateMachine:biomage-qc-test-b2bacc54e31beb2bda7b4bd9b1ec33ec84eae60f",
       "traceHeader": undefined,
     },
   },

--- a/tests/api/general-services/__snapshots__/state-machine-definition.test.js.snap
+++ b/tests/api/general-services/__snapshots__/state-machine-definition.test.js.snap
@@ -20,7 +20,7 @@ exports[`non-tests to document the State Machines - gem2s cloud 1`] = `
         "Path": "/apis/helm.fluxcd.io/v1/namespaces/pipeline-test-namespace/helmreleases",
         "QueryParameters": {
           "labelSelector": [
-            "type=pipeline,sandboxId=undefined,experimentId=mock-experiment-id"
+            "type=pipeline,sandboxId=default,experimentId=mock-experiment-id"
           ]
         }
       }
@@ -47,6 +47,7 @@ exports[`non-tests to document the State Machines - gem2s cloud 1`] = `
               "fluxcd.io/automated": "true"
             },
             "labels": {
+              "sandboxId": "default",
               "type": "pipeline",
               "experimentId": "mock-experiment-id"
             }
@@ -60,6 +61,7 @@ exports[`non-tests to document the State Machines - gem2s cloud 1`] = `
             "values": {
               "experimentId": "mock-experiment-id",
               "namespace": "pipeline-test-namespace",
+              "sandboxId": "default",
               "awsAccountId": "mock-account-id",
               "clusterEnv": "test",
               "awsRegion": "eu-west-1"
@@ -330,7 +332,7 @@ exports[`non-tests to document the State Machines - qc cloud 1`] = `
         "Path": "/apis/helm.fluxcd.io/v1/namespaces/pipeline-test-namespace/helmreleases",
         "QueryParameters": {
           "labelSelector": [
-            "type=pipeline,sandboxId=undefined,experimentId=mock-experiment-id"
+            "type=pipeline,sandboxId=default,experimentId=mock-experiment-id"
           ]
         }
       }
@@ -357,6 +359,7 @@ exports[`non-tests to document the State Machines - qc cloud 1`] = `
               "fluxcd.io/automated": "true"
             },
             "labels": {
+              "sandboxId": "default",
               "type": "pipeline",
               "experimentId": "mock-experiment-id"
             }
@@ -370,6 +373,7 @@ exports[`non-tests to document the State Machines - qc cloud 1`] = `
             "values": {
               "experimentId": "mock-experiment-id",
               "namespace": "pipeline-test-namespace",
+              "sandboxId": "default",
               "awsAccountId": "mock-account-id",
               "clusterEnv": "test",
               "awsRegion": "eu-west-1"

--- a/tests/api/general-services/work-submit.test.js
+++ b/tests/api/general-services/work-submit.test.js
@@ -29,7 +29,7 @@ describe('tests for the work-submit service', () => {
       expect(sendMessageSpy).toHaveBeenCalledWith(
         {
           MessageBody: JSON.stringify(workRequest),
-          QueueUrl: 'https://sqs.eu-west-1.amazonaws.com/test-account-id/queue-job-c55f9dd848349af0832dce12345f72ca743fb713-test.fifo',
+          QueueUrl: 'https://sqs.eu-west-1.amazonaws.com/test-account-id/queue-job-1cd932135df1889ebf59575eb8fbe4b6c29858ee-test.fifo',
           MessageGroupId: 'work',
         },
       );

--- a/tests/api/general-services/work-submit.test.js
+++ b/tests/api/general-services/work-submit.test.js
@@ -25,11 +25,18 @@ describe('tests for the work-submit service', () => {
 
     const w = new WorkSubmitService(workRequest);
     w.submitWork().then(() => {
-      expect(sendMessageSpy).toHaveBeenCalledTimes(1);
+      expect(sendMessageSpy).toHaveBeenCalledTimes(2);
       expect(sendMessageSpy).toHaveBeenCalledWith(
         {
           MessageBody: JSON.stringify(workRequest),
           QueueUrl: 'https://sqs.eu-west-1.amazonaws.com/test-account-id/queue-job-c55f9dd848349af0832dce12345f72ca743fb713-test.fifo',
+          MessageGroupId: 'work',
+        },
+      );
+      expect(sendMessageSpy).toHaveBeenCalledWith(
+        {
+          MessageBody: JSON.stringify(workRequest),
+          QueueUrl: 'https://sqs.eu-west-1.amazonaws.com/test-account-id/queue-job-default-test.fifo',
           MessageGroupId: 'work',
         },
       );

--- a/tests/utils/cache-request.test.js
+++ b/tests/utils/cache-request.test.js
@@ -32,7 +32,7 @@ describe('cache(Get/Set)Request', () => {
 
   beforeAll(() => {
     CacheSingleton.createMock({
-      eab532552ba5bdda14c059f6a103a5d3: { result: 'valueInL1' }, // pragma: allowlist secret
+      d7c612d3d09f3977130241c744b5baba: { result: 'valueInL1' }, // pragma: allowlist secret
     });
 
     cache = CacheSingleton.get();
@@ -53,7 +53,7 @@ describe('cache(Get/Set)Request', () => {
       expect(e).toBeInstanceOf(CacheMissError);
     }
 
-    expect(cache.get).toHaveBeenCalledWith('ee7d703dee8af14cc23823fabbac08b8'); // pragma: allowlist secret
+    expect(cache.get).toHaveBeenCalledWith('c5b7ac78783be95c0f4152b5de225e96'); // pragma: allowlist secret
     expect(result).toBe(undefined);
   });
 
@@ -62,13 +62,13 @@ describe('cache(Get/Set)Request', () => {
     const result = await cacheGetRequest(newRequest, () => null, socket);
 
     expect(result).toEqual({ result: 'valueInL1' });
-    expect(cache.get).toHaveBeenCalledWith('eab532552ba5bdda14c059f6a103a5d3'); // pragma: allowlist secret
+    expect(cache.get).toHaveBeenCalledWith('d7c612d3d09f3977130241c744b5baba'); // pragma: allowlist secret
   });
 
   it('cacheSetResponse', async () => {
     await cacheSetResponse(response);
 
-    expect(cache.set).toHaveBeenCalledWith('ee7d703dee8af14cc23823fabbac08b8', { // pragma: allowlist secret
+    expect(cache.set).toHaveBeenCalledWith('c5b7ac78783be95c0f4152b5de225e96', { // pragma: allowlist secret
       request,
       result: response.result,
     }, 129600);


### PR DESCRIPTION
# Background
#### Link to issue 
https://biomage.atlassian.net/browse/BIOMAGE-1211

#### Link to staging deployment URL 
https://ui-marcellp-api193.scp-staging.biomage.net/

#### Links to any Pull Requests related to this
N/A

#### Anything else the reviewers should know about the changes here
The scope of this ticket changed due to issues around the message group ID.

# Changes
### Code changes
Added a function that automatically sends all work requests to a per-environment queue that does not discriminate based on experiment ID. This can be used by unassigned workers to get all messages so they can pick up work for unassigned experiments.

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
