### PR TITLE
[BIOMAGE-1226] Implement the backend for download of the raw Seurat object

### DIFF
--- a/src/api/route-services/experiment.js
+++ b/src/api/route-services/experiment.js
@@ -342,10 +342,13 @@ class ExperimentService {
     let bucket = '';
     let downloadedFileName = '';
 
+    if (!Object.values(downloadTypes).includes(downloadType)) throw new BadRequestError('Invalid download type requested');
+
     const { projectId } = await getExperimentAttributes(this.experimentsTableName, experimentId, ['projectId']);
     const filenamePrefix = projectId.split('-')[0];
 
     // Also defined in UI repo in utils/downloadTypes
+    // eslint-disable-next-line default-case
     switch (downloadType) {
       case downloadTypes.PROCESSED_SEURAT_OBJECT:
         bucket = this.processedMatrixBucketName;
@@ -357,9 +360,8 @@ class ExperimentService {
         objectKey = `${experimentId}/r.rds`;
         downloadedFileName = `${filenamePrefix}_raw_matrix.rds`;
         break;
-      default:
-        throw new BadRequestError('Invalid download type requested');
     }
+
 
     const s3 = new AWS.S3();
 

--- a/src/api/route-services/experiment.js
+++ b/src/api/route-services/experiment.js
@@ -27,8 +27,9 @@ class ExperimentService {
     this.experimentsTableName = `experiments-${config.clusterEnv}`;
     this.cellSetsBucketName = `cell-sets-${config.clusterEnv}`;
     this.processedMatrixBucketName = `processed-matrix-${config.clusterEnv}`;
+    this.rawSeuratBucketName = `biomage-source-${config.clusterEnv}`;
 
-    mockData.matrixPath = mockData.matrixPath.replace('BUCKET_NAME', `biomage-source-${config.clusterEnv}`);
+    mockData.matrixPath = mockData.matrixPath.replace('BUCKET_NAME', this.rawSeuratBucketName);
     this.mockData = convertToDynamoDbRecord(mockData);
   }
 
@@ -334,6 +335,9 @@ class ExperimentService {
     // Also defined in UI repo in utils/downloadTypes
     if (downloadType === downloadTypes.PROCESSED_SEURAT_OBJECT) {
       bucket = this.processedMatrixBucketName;
+      objectKey = `${experimentId}/r.rds`;
+    } else if (downloadType === downloadTypes.RAW_SEURAT_OBJECT) {
+      bucket = this.rawSeuratBucketName;
       objectKey = `${experimentId}/r.rds`;
     } else {
       throw new BadRequestError('Invalid download type requested');

--- a/src/utils/downloadTypes.js
+++ b/src/utils/downloadTypes.js
@@ -1,5 +1,6 @@
 const downloadTypes = {
   PROCESSED_SEURAT_OBJECT: 'processed_seurat_object',
+  RAW_SEURAT_OBJECT: 'raw_seurat_object',
 };
 
 module.exports = downloadTypes;


### PR DESCRIPTION
# Background
#### Link to issue 
https://biomage.atlassian.net/secure/RapidBoard.jspa?rapidView=1&projectKey=BIOMAGE&modal=detail&selectedIssue=BIOMAGE-1226
#### Link to staging deployment URL 
https://ui-grasp6-ui420-api196.scp-staging.biomage.net/
#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
