### PR TITLE
modify api schema allow error response from gem2s

### DIFF
--- a/src/specs/models/GEM2SResponse.v1.yaml
+++ b/src/specs/models/GEM2SResponse.v1.yaml
@@ -2,32 +2,24 @@ title: GEM2S response
 description: This is the format the gem2s clients communicate the result of a gem2s run.
 type: object
 properties:
-  oneOf:
-    - experimentId:
-        type: string
-      taskName:
-        type: string
-      oneOf:
-        - item:
-            $ref: ./api-body-schemas/Experiment.v1.yaml
-          table:
-            type: string
-            pattern: 'experiments'
-        - item:
-            $ref: ./api-body-schemas/Samples.v1.yaml
-          table:
-            type: string
-            pattern: 'samples'
-      required:
-        - experimentId
-        - taskName
-    - response:
-        type: object
-        properties:
-          error:
-            description: "Whether there's been an error."
-            oneOf:
-              - type: string
-              - type: boolean
-          required: 
-            - error
+  experimentId:
+    type: string
+  taskName:
+    type: string
+  data:
+    anyOf:
+      - type: object
+      - type: array
+  response:
+    type: object
+    properties:
+      error:
+        description: Whether there's been an error.
+        oneOf:
+          - type: string
+          - type: boolean
+    required:
+      - error
+required:
+  - experimentId
+  - taskName


### PR DESCRIPTION
# Background
#### Link to issue 

GEM2S response does not contain response.error body by default. It only has this property when there is error. This PR allows the API schema to contain `response.error` in the GEM2S response body. This property is used by testing to check if there are errors in the response.

#### Link to staging deployment URL 

https://ui-agi-api209-pipeline144.scp-staging.biomage.net/

#### Links to any Pull Requests related to this

API -  https://github.com/biomage-ltd/api/pull/209
Pipeline - https://github.com/biomage-ltd/pipeline/pull/144

#### Anything else the reviewers should know about the changes here

- Change API schema to allow for `response.error`.

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [X] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [X] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
