### PR TITLE
[BIOMAGE-1295] Provide a way for users to easily upload and explore public datasets

### DIFF
--- a/src/api/route-services/experiment.js
+++ b/src/api/route-services/experiment.js
@@ -375,6 +375,24 @@ class ExperimentService {
     const signedUrl = s3.getSignedUrl('getObject', params);
     return { signedUrl };
   }
+
+  // eslint-disable-next-line class-methods-use-this
+  async downloadPublicDataset() {
+    console.log('HERE!!!');
+    const s3 = new AWS.S3();
+
+    const folderName = 'pbmc_10k_v3/pbmc_10k';
+    const bucket = 'biomage-originals-production';
+    const downloadedFileName = 'pbmc_10k';
+    const params = {
+      Bucket: bucket,
+      Key: folderName,
+      ResponseContentDisposition: `attachment; filename ="${downloadedFileName}"`,
+    };
+    const signedUrl = s3.getSignedUrl('getObject', params);
+    console.log('SIGNED URL IS ', signedUrl);
+    return { signedUrl };
+  }
 }
 
 module.exports = ExperimentService;

--- a/src/api/routes/experiment.js
+++ b/src/api/routes/experiment.js
@@ -69,4 +69,12 @@ module.exports = {
         .catch(next);
     },
   ],
+
+  'experiment#downloadPublicDataset': [
+    (req, res, next) => {
+      experimentService.downloadPublicDataset()
+        .then((data) => res.json(data))
+        .catch(next);
+    },
+  ],
 };

--- a/src/specs/api.yaml
+++ b/src/specs/api.yaml
@@ -455,6 +455,32 @@ paths:
         description: Updates the keys specified by `name` with the body specified by `body`. A standard DynamoDB UpdateItem request should be called on the update.
       tags:
         - processing-config
+  /downloadPublicDataset:
+    get:
+      summary: get the public pbmc dataset from s3
+      x-eov-operation-id: experiment#downloadPublicDataset
+      x-eov-operation-handler: routes/experiment
+      tags: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties: 
+                  signedUrl:
+                    type: string
+                    description: signed URL of the resource
+        '404':
+          description: Dataset not found
+          content:
+            application/json:
+              schema:
+                $ref: ./models/HTTPError.v1.yaml
+      operationId: get-publicDataset
+      description: Download successfull
+
   '/experiments/{experimentId}/download/{type}':
     get:
       summary: Download data according to the requested type
@@ -468,7 +494,7 @@ paths:
             application/json:
               schema:
                 type: object
-                properties: 
+                properties:
                   signedUrl:
                     type: string
                     description: signed URL of the resource
@@ -1014,3 +1040,4 @@ paths:
             application/json:
               schema:
                 $ref: ./models/HTTPError.v1.yaml
+


### PR DESCRIPTION
# Background
#### Link to issue 
https://biomage.atlassian.net/secure/RapidBoard.jspa?rapidView=1&projectKey=BIOMAGE&modal=detail&selectedIssue=BIOMAGE-1295
#### Link to staging deployment URL 
https://ui-stefan-ui476-api215.scp-staging.biomage.net/
#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
