### PR TITLE
[BIOMAGE-1184] - Add gem2s hash params to returned backend status

### DIFF
--- a/src/api/general-services/pipeline-status.js
+++ b/src/api/general-services/pipeline-status.js
@@ -3,7 +3,7 @@ const AWS = require('../../utils/requireAWS');
 const ExperimentService = require('../route-services/experiment');
 const config = require('../../config');
 const getLogger = require('../../utils/getLogger');
-const pipelineConstants = require('./pipeline-manage/constants');
+const constants = require('./pipeline-manage/constants');
 
 const logger = getLogger();
 
@@ -18,7 +18,7 @@ const privateSteps = [
 const notCreatedStatus = {
   startDate: null,
   stopDate: null,
-  status: pipelineConstants.NOT_CREATED,
+  status: constants.NOT_CREATED,
   error: false,
   completedSteps: [],
 };
@@ -183,7 +183,7 @@ const getPipelineStatus = async (experimentId, processName) => {
   } catch (e) {
     // state machines in staging are removed after some time, in this situation we return
     // NOT_CREATED status so that the pipeline can be run again
-    if (config.clusterEnv === 'staging' && e.code === pipelineConstants.EXECUTION_DOES_NOT_EXIST) {
+    if (config.clusterEnv === 'staging' && e.code === constants.EXECUTION_DOES_NOT_EXIST) {
       return {
         [processName]: notCreatedStatus,
       };
@@ -192,8 +192,8 @@ const getPipelineStatus = async (experimentId, processName) => {
     // if we get the execution does not exist it means we are using a pulled experiment so
     // just return a mock sucess status
     if (
-      (config.clusterEnv === 'development' && e.code === pipelineConstants.EXECUTION_DOES_NOT_EXIST)
-      || (config.clusterEnv === 'staging' && e.code === pipelineConstants.ACCESS_DENIED)
+      (config.clusterEnv === 'development' && e.code === constants.EXECUTION_DOES_NOT_EXIST)
+      || (config.clusterEnv === 'staging' && e.code === constants.ACCESS_DENIED)
     ) {
       logger.log(
         `Returning a mocked success ${processName} - pipeline status because ARN ${executionArn} `
@@ -240,6 +240,11 @@ const getPipelineStatus = async (experimentId, processName) => {
       completedSteps,
     },
   };
+
+  if (processName === constants.GEM2S_PROCESS_NAME) {
+    const { paramsHash } = pipelinesHandles[constants.GEM2S_PROCESS_NAME];
+    response[constants.GEM2S_PROCESS_NAME].paramsHash = paramsHash;
+  }
 
   return response;
 };

--- a/src/api/general-services/pipeline-status.js
+++ b/src/api/general-services/pipeline-status.js
@@ -3,7 +3,7 @@ const AWS = require('../../utils/requireAWS');
 const ExperimentService = require('../route-services/experiment');
 const config = require('../../config');
 const getLogger = require('../../utils/getLogger');
-const constants = require('./pipeline-manage/constants');
+const pipelineConstants = require('./pipeline-manage/constants');
 
 const logger = getLogger();
 
@@ -18,7 +18,7 @@ const privateSteps = [
 const notCreatedStatus = {
   startDate: null,
   stopDate: null,
-  status: constants.NOT_CREATED,
+  status: pipelineConstants.NOT_CREATED,
   error: false,
   completedSteps: [],
 };
@@ -183,7 +183,7 @@ const getPipelineStatus = async (experimentId, processName) => {
   } catch (e) {
     // state machines in staging are removed after some time, in this situation we return
     // NOT_CREATED status so that the pipeline can be run again
-    if (config.clusterEnv === 'staging' && e.code === constants.EXECUTION_DOES_NOT_EXIST) {
+    if (config.clusterEnv === 'staging' && e.code === pipelineConstants.EXECUTION_DOES_NOT_EXIST) {
       return {
         [processName]: notCreatedStatus,
       };
@@ -192,8 +192,8 @@ const getPipelineStatus = async (experimentId, processName) => {
     // if we get the execution does not exist it means we are using a pulled experiment so
     // just return a mock sucess status
     if (
-      (config.clusterEnv === 'development' && e.code === constants.EXECUTION_DOES_NOT_EXIST)
-      || (config.clusterEnv === 'staging' && e.code === constants.ACCESS_DENIED)
+      (config.clusterEnv === 'development' && e.code === pipelineConstants.EXECUTION_DOES_NOT_EXIST)
+      || (config.clusterEnv === 'staging' && e.code === pipelineConstants.ACCESS_DENIED)
     ) {
       logger.log(
         `Returning a mocked success ${processName} - pipeline status because ARN ${executionArn} `
@@ -241,9 +241,9 @@ const getPipelineStatus = async (experimentId, processName) => {
     },
   };
 
-  if (processName === constants.GEM2S_PROCESS_NAME) {
-    const { paramsHash } = pipelinesHandles[constants.GEM2S_PROCESS_NAME];
-    response[constants.GEM2S_PROCESS_NAME].paramsHash = paramsHash;
+  if (processName === pipelineConstants.GEM2S_PROCESS_NAME) {
+    const { paramsHash } = pipelinesHandles[pipelineConstants.GEM2S_PROCESS_NAME];
+    response[pipelineConstants.GEM2S_PROCESS_NAME].paramsHash = paramsHash;
   }
 
   return response;

--- a/src/api/route-services/__mocks__/gem2s.js
+++ b/src/api/route-services/__mocks__/gem2s.js
@@ -1,0 +1,16 @@
+const mockGem2sCreate = jest.fn(() => Promise.resolve({
+  stateMachineArn: 'arn:aws:states:eu-east-1:3139055674710:stateMachine:biomage-gem2s-production-2367819df529419d7c95167336f5d6ae681859b2',
+  executionArn: 'arn:aws:states:eu-east-1:3139055674710:execution:biomage-gem2s-production-2367819df529419d7c95167336f5d6ae681859b2:90b4bc06-507e-41e3-ae0b-fc9cc83cnm3f',
+}));
+
+const mockGem2sResponse = jest.fn(() => Promise.resolve({}));
+
+const mockGenerateGem2sParams = jest.fn(() => {});
+
+const mock = jest.fn().mockImplementation(() => ({
+  gem2sCreate: mockGem2sCreate,
+  gem2sResponse: mockGem2sResponse,
+  generateGem2sParams: mockGenerateGem2sParams,
+}));
+
+module.exports = mock;

--- a/src/api/route-services/__mocks__/gem2s.js
+++ b/src/api/route-services/__mocks__/gem2s.js
@@ -7,10 +7,10 @@ const mockGem2sResponse = jest.fn(() => Promise.resolve({}));
 
 const mockGenerateGem2sParams = jest.fn(() => {});
 
-const mock = jest.fn().mockImplementation(() => ({
+const mock = {
   gem2sCreate: mockGem2sCreate,
   gem2sResponse: mockGem2sResponse,
   generateGem2sParams: mockGenerateGem2sParams,
-}));
+};
 
 module.exports = mock;

--- a/src/api/route-services/__mocks__/gem2s.js
+++ b/src/api/route-services/__mocks__/gem2s.js
@@ -1,6 +1,6 @@
 const mockGem2sCreate = jest.fn(() => Promise.resolve({
-  stateMachineArn: 'arn:aws:states:eu-east-1:3139055674710:stateMachine:biomage-gem2s-production-2367819df529419d7c95167336f5d6ae681859b2',
-  executionArn: 'arn:aws:states:eu-east-1:3139055674710:execution:biomage-gem2s-production-2367819df529419d7c95167336f5d6ae681859b2:90b4bc06-507e-41e3-ae0b-fc9cc83cnm3f',
+  stateMachineArn: 'arn:aws:states:eu-east-1:3139055674710:stateMachine:biomage-gem2s-testing-2367819df529419d7c95167336f5d6ae681859b2',
+  executionArn: 'arn:aws:states:eu-east-1:3139055674710:execution:biomage-gem2s-testing-2367819df529419d7c95167336f5d6ae681859b2:90b4bc06-507e-41e3-ae0b-fc9cc83cnm3f',
 }));
 
 const mockGem2sResponse = jest.fn(() => Promise.resolve({}));

--- a/src/api/route-services/gem2s.js
+++ b/src/api/route-services/gem2s.js
@@ -1,12 +1,9 @@
 const _ = require('lodash');
 const AWSXRay = require('aws-xray-sdk');
 
-const crypto = require('crypto');
 const constants = require('../general-services/pipeline-manage/constants');
 const getPipelineStatus = require('../general-services/pipeline-status');
 const { createGem2SPipeline } = require('../general-services/pipeline-manage');
-
-const { GEM2S_PROCESS_NAME, RUNNING, SUCCEEDED } = require('../general-services/pipeline-manage/constants');
 
 const saveProcessingConfigFromGem2s = require('../../utils/hooks/saveProcessingConfigFromGem2s');
 const runQCPipeline = require('../../utils/hooks/runQCPipeline');
@@ -81,57 +78,18 @@ class Gem2sService {
       }, {});
     }
 
-    // Different sample order should not change the hash.
-    const orderInvariantSampleIds = [...experiment.sampleIds].sort();
-
-    const hashParams = {
-      organism: experiment.meta.organism,
-      input: { type: experiment.meta.type },
-      sampleIds: orderInvariantSampleIds,
-      sampleNames: orderInvariantSampleIds.map((sampleId) => samples[sampleId].name),
-      metadata: taskParams.metadata,
-    };
-
-    return { taskParams, hashParams };
+    return taskParams;
   }
 
-  static async gem2sShouldRun(experimentId, paramsHash) {
-    logger.log('Checking if gem2s should actually be re run');
-
-    const experimentService = new ExperimentService();
-
-    const handlesPromise = experimentService.getPipelinesHandles(experimentId);
-    const statusPromise = getPipelineStatus(experimentId, GEM2S_PROCESS_NAME);
-
-    const [handles, statusWrapper] = await Promise.all([handlesPromise, statusPromise]);
-
-    const { [GEM2S_PROCESS_NAME]: gem2sHandle } = handles;
-    const { [GEM2S_PROCESS_NAME]: { status: gem2sStatus } } = statusWrapper;
-
-    logger.log(`Gem2s status is ${gem2sStatus}. new hash: ${paramsHash}; old hash: ${gem2sHandle.paramsHash}`);
-    if (gem2sStatus === SUCCEEDED) {
-      return paramsHash !== gem2sHandle.paramsHash;
-    }
-
-    return gem2sStatus !== RUNNING;
-  }
-
-  static async gem2sCreate(experimentId, authJWT) {
-    const { taskParams, hashParams } = await this.generateGem2sParams(experimentId, authJWT);
-
-    const paramsHash = crypto
-      .createHash('sha1')
-      .update(JSON.stringify(hashParams))
-      .digest('hex');
-
-    const shouldRun = await this.gem2sShouldRun(experimentId, paramsHash);
+  static async gem2sCreate(experimentId, body, authJWT) {
+    const { shouldRun, gem2sHash: paramsHash } = body;
 
     if (!shouldRun) {
       logger.log('Gem2s create call ignored');
       return OK();
     }
 
-    logger.log('Running new gem2s pipeline');
+    const taskParams = await this.generateGem2sParams(experimentId, authJWT);
 
     const newHandle = await createGem2SPipeline(experimentId, taskParams);
 

--- a/src/api/route-services/gem2s.js
+++ b/src/api/route-services/gem2s.js
@@ -9,7 +9,6 @@ const saveProcessingConfigFromGem2s = require('../../utils/hooks/saveProcessingC
 const runQCPipeline = require('../../utils/hooks/runQCPipeline');
 const validateRequest = require('../../utils/schema-validator');
 const PipelineHook = require('../../utils/hookRunner');
-const { OK } = require('../../utils/responses');
 const getLogger = require('../../utils/getLogger');
 
 const ExperimentService = require('./experiment');
@@ -82,12 +81,7 @@ class Gem2sService {
   }
 
   static async gem2sCreate(experimentId, body, authJWT) {
-    const { shouldRun, gem2sHash: paramsHash } = body;
-
-    if (!shouldRun) {
-      logger.log('Gem2s create call ignored');
-      return OK();
-    }
+    const { paramsHash } = body;
 
     const taskParams = await this.generateGem2sParams(experimentId, authJWT);
 

--- a/src/api/route-services/gem2s.js
+++ b/src/api/route-services/gem2s.js
@@ -90,7 +90,9 @@ class Gem2sService {
     logger.log('Creating GEM2S params...');
     const { paramsHash } = body;
 
-    const taskParams = await this.generateGem2sParams(experimentId, authJWT);
+    // Accessing a static param from an instance method, you need to use this.constructor
+    // https://stackoverflow.com/questions/28627908/call-static-methods-from-regular-es6-class-methods
+    const taskParams = await this.constructor.generateGem2sParams(experimentId, authJWT);
 
     const newHandle = await createGem2SPipeline(experimentId, taskParams);
 
@@ -130,7 +132,7 @@ class Gem2sService {
     // Make sure authJWT doesn't get back to the client
     delete messageForClient.authJWT;
 
-    await this.sendUpdateToSubscribed(experimentId, messageForClient, io);
+    await this.constructor.sendUpdateToSubscribed(experimentId, messageForClient, io);
   }
 }
 

--- a/src/api/route-services/gem2s.js
+++ b/src/api/route-services/gem2s.js
@@ -86,13 +86,11 @@ class Gem2sService {
     return taskParams;
   }
 
-  async gem2sCreate(experimentId, body, authJWT) {
+  static async gem2sCreate(experimentId, body, authJWT) {
     logger.log('Creating GEM2S params...');
     const { paramsHash } = body;
 
-    // Accessing a static param from an instance method, you need to use this.constructor
-    // https://stackoverflow.com/questions/28627908/call-static-methods-from-regular-es6-class-methods
-    const taskParams = await this.constructor.generateGem2sParams(experimentId, authJWT);
+    const taskParams = await Gem2sService.generateGem2sParams(experimentId, authJWT);
 
     const newHandle = await createGem2SPipeline(experimentId, taskParams);
 
@@ -110,7 +108,7 @@ class Gem2sService {
     return newHandle;
   }
 
-  async gem2sResponse(io, message) {
+  static async gem2sResponse(io, message) {
     AWSXRay.getSegment().addMetadata('message', message);
 
     // Fail hard if there was an error.
@@ -132,7 +130,7 @@ class Gem2sService {
     // Make sure authJWT doesn't get back to the client
     delete messageForClient.authJWT;
 
-    await this.constructor.sendUpdateToSubscribed(experimentId, messageForClient, io);
+    await Gem2sService.sendUpdateToSubscribed(experimentId, messageForClient, io);
   }
 }
 

--- a/src/api/routes/gem2s.js
+++ b/src/api/routes/gem2s.js
@@ -7,13 +7,15 @@ const { expressAuthorizationMiddleware } = require('../../utils/authMiddlewares'
 
 const logger = getLogger();
 
+const gem2sService = new Gem2sService();
+
 module.exports = {
   'gem2s#create': [
     expressAuthorizationMiddleware,
     async (req, res, next) => {
       const { experimentId } = req.params;
 
-      Gem2sService.gem2sCreate(experimentId, req.body, req.headers.authorization)
+      gem2sService.gem2sCreate(experimentId, req.body, req.headers.authorization)
         .then((response) => res.json(response))
         .catch(next);
     },
@@ -35,7 +37,7 @@ module.exports = {
     const isSnsNotification = parsedMessage !== undefined;
     if (isSnsNotification) {
       try {
-        await Gem2sService.gem2sResponse(io, parsedMessage);
+        await gem2sService.gem2sResponse(io, parsedMessage);
       } catch (e) {
         logger.error(
           'gem2s pipeline response handler failed with error: ', e,

--- a/src/api/routes/gem2s.js
+++ b/src/api/routes/gem2s.js
@@ -7,15 +7,13 @@ const { expressAuthorizationMiddleware } = require('../../utils/authMiddlewares'
 
 const logger = getLogger();
 
-const gem2sService = new Gem2sService();
-
 module.exports = {
   'gem2s#create': [
     expressAuthorizationMiddleware,
     async (req, res, next) => {
       const { experimentId } = req.params;
 
-      gem2sService.gem2sCreate(experimentId, req.body, req.headers.authorization)
+      Gem2sService.gem2sCreate(experimentId, req.body, req.headers.authorization)
         .then((response) => res.json(response))
         .catch(next);
     },
@@ -37,7 +35,7 @@ module.exports = {
     const isSnsNotification = parsedMessage !== undefined;
     if (isSnsNotification) {
       try {
-        await gem2sService.gem2sResponse(io, parsedMessage);
+        await Gem2sService.gem2sResponse(io, parsedMessage);
       } catch (e) {
         logger.error(
           'gem2s pipeline response handler failed with error: ', e,

--- a/src/api/routes/gem2s.js
+++ b/src/api/routes/gem2s.js
@@ -13,7 +13,7 @@ module.exports = {
     async (req, res, next) => {
       const { experimentId } = req.params;
 
-      Gem2sService.gem2sCreate(experimentId, req.headers.authorization)
+      Gem2sService.gem2sCreate(experimentId, req.body, req.headers.authorization)
         .then((response) => res.json(response))
         .catch(next);
     },

--- a/src/specs/api.yaml
+++ b/src/specs/api.yaml
@@ -26,7 +26,7 @@ paths:
         - heartbeat
       summary: API health check
       operationId: checkHealth
-      x-eov-operation-id: 'health#check'
+      x-eov-operation-id: health#check
       x-eov-operation-handler: routes/health
       responses:
         '200':
@@ -61,7 +61,7 @@ paths:
   /gem2sResults:
     post:
       operationId: receiveGem2sResponse
-      x-eov-operation-id: 'gem2s#response'
+      x-eov-operation-id: gem2s#response
       x-eov-operation-handler: routes/gem2s
       requestBody:
         description: 'The results from the execution of a pipeline step, sent via SNS.'
@@ -104,7 +104,7 @@ paths:
   /pipelineResults:
     post:
       operationId: receivePipelineResponse
-      x-eov-operation-id: 'pipelines#response'
+      x-eov-operation-id: pipelines#response
       x-eov-operation-handler: routes/pipelines
       requestBody:
         description: 'The results from the execution of a pipeline step, sent via SNS.'
@@ -151,7 +151,7 @@ paths:
       summary: Get experiment details
       description: Returns the main details of the experiment.
       operationId: getExperiment
-      x-eov-operation-id: 'experiment#getExperiment'
+      x-eov-operation-id: experiment#getExperiment
       x-eov-operation-handler: routes/experiment
       responses:
         '200':
@@ -189,7 +189,7 @@ paths:
       summary: Create experiment
       description: Create a new experiment
       operationId: createExperiment
-      x-eov-operation-id: 'experiment#createExperiment'
+      x-eov-operation-id: experiment#createExperiment
       x-eov-operation-handler: routes/experiment
       responses:
         '200':
@@ -213,7 +213,7 @@ paths:
     put:
       summary: ''
       operationId: updateExperiment
-      x-eov-operation-id: 'experiment#updateExperiment'
+      x-eov-operation-id: experiment#updateExperiment
       x-eov-operation-handler: routes/experiment
       responses:
         '200':
@@ -248,7 +248,7 @@ paths:
       summary: Get cell sets for experiment
       description: Returns a hirearchical view of cell sets in the experiment.
       operationId: getExperimentCellSetsById
-      x-eov-operation-id: 'experiment#getCellSets'
+      x-eov-operation-id: experiment#getCellSets
       x-eov-operation-handler: routes/experiment
       responses:
         '200':
@@ -290,7 +290,7 @@ paths:
     put:
       summary: ''
       operationId: updateExperimentCellSetsById
-      x-eov-operation-id: 'experiment#updateCellSets'
+      x-eov-operation-id: experiment#updateCellSets
       x-eov-operation-handler: routes/experiment
       responses:
         '200':
@@ -328,7 +328,7 @@ paths:
     patch:
       summary: ''
       operationId: patchExperimentCellSetsById
-      x-eov-operation-id: 'experiment#patchCellSets'
+      x-eov-operation-id: experiment#patchCellSets
       x-eov-operation-handler: routes/experiment
       responses:
         '200':
@@ -352,7 +352,7 @@ paths:
             application/json:
               schema:
                 $ref: ./models/HTTPError.v1.yaml
-      description: "Performs a partial update on the experiment's cell sets."
+      description: Performs a partial update on the experiment's cell sets.
       requestBody:
         content:
           application/boschni-json-merger+json:
@@ -367,7 +367,7 @@ paths:
       summary: Retrieve processing configuration
       description: Returns a hirearchical view of processing configuration used in the experiment.
       operationId: getExperimentProcessingConfigById
-      x-eov-operation-id: 'experiment#getProcessingConfig'
+      x-eov-operation-id: experiment#getProcessingConfig
       x-eov-operation-handler: routes/experiment
       responses:
         '200':
@@ -406,7 +406,7 @@ paths:
     put:
       summary: ''
       operationId: updateExperimentProcessingConfigById
-      x-eov-operation-id: 'experiment#updateProcessingConfig'
+      x-eov-operation-id: experiment#updateProcessingConfig
       x-eov-operation-handler: routes/experiment
       responses:
         '200':
@@ -453,7 +453,7 @@ paths:
     get:
       summary: Download data according to the requested type
       operationId: downloadExperimentData
-      x-eov-operation-id: 'experiment#downloadData'
+      x-eov-operation-id: experiment#downloadData
       x-eov-operation-handler: routes/experiment
       responses:
         '200':
@@ -528,7 +528,7 @@ paths:
     put:
       summary: ''
       operationId: updatePlotTable
-      x-eov-operation-id: 'plots-tables#update'
+      x-eov-operation-id: plots-tables#update
       x-eov-operation-handler: routes/plots-tables
       responses:
         '200':
@@ -567,7 +567,7 @@ paths:
     get:
       summary: ''
       operationId: getPlotTable
-      x-eov-operation-id: 'plots-tables#read'
+      x-eov-operation-id: plots-tables#read
       x-eov-operation-handler: routes/plots-tables
       responses:
         '200':
@@ -598,7 +598,7 @@ paths:
     delete:
       summary: ''
       operationId: deletePlotTable
-      x-eov-operation-id: 'plots-tables#delete'
+      x-eov-operation-id: plots-tables#delete
       x-eov-operation-handler: routes/plots-tables
       responses:
         '200':
@@ -626,7 +626,7 @@ paths:
     post:
       summary: Create a new pipeline for gem2s execution
       operationId: createNewGem2S
-      x-eov-operation-id: 'gem2s#create'
+      x-eov-operation-id: gem2s#create
       x-eov-operation-handler: routes/gem2s
       responses:
         '200':
@@ -635,8 +635,22 @@ paths:
             application/json:
               schema:
                 type: object
-                properties: {}
+                properties:
+                  paramsHash:
+                    type: string
       description: This path will create a new pipeline that can run a state machine with gem2s tasks.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                paramsHash:
+                  type: string
+              required:
+                - paramsHash
+        description: Request body for GEM2S request
+      parameters: []
   '/experiments/{experimentId}/pipelines':
     parameters:
       - schema:
@@ -647,7 +661,7 @@ paths:
     post:
       summary: Create a new pipeline for taks execution
       operationId: createNewPipeline
-      x-eov-operation-id: 'pipelines#create'
+      x-eov-operation-id: pipelines#create
       x-eov-operation-handler: routes/pipelines
       responses:
         '200':
@@ -675,7 +689,7 @@ paths:
       summary: Create new pipeline
       description: Endpoint to download files
       operationId: get-experiments-experimentId-pipelines
-      x-eov-operation-id: 'backend-status#get'
+      x-eov-operation-id: backend-status#get
       x-eov-operation-handler: routes/backend-status
       responses:
         '200':
@@ -720,7 +734,7 @@ paths:
     get:
       summary: Your GET endpoint
       operationId: getSamplesByExperimentId
-      x-eov-operation-id: 'samples#getSamplesByExperimentId'
+      x-eov-operation-id: samples#getSamplesByExperimentId
       x-eov-operation-handler: routes/samples
       tags: []
       responses:
@@ -759,7 +773,7 @@ paths:
     put:
       summary: Update project
       operationId: updateProject
-      x-eov-operation-id: 'projects#update'
+      x-eov-operation-id: projects#update
       x-eov-operation-handler: routes/projects
       responses:
         '200':
@@ -808,7 +822,7 @@ paths:
     delete:
       summary: Deletes the project
       operationId: deleteProject
-      x-eov-operation-id: 'projects#delete'
+      x-eov-operation-id: projects#delete
       x-eov-operation-handler: routes/projects
       responses:
         '200':
@@ -834,7 +848,7 @@ paths:
     get:
       summary: Get experiments under a project
       operationId: getProjectExperiments
-      x-eov-operation-id: 'projects#getExperiments'
+      x-eov-operation-id: projects#getExperiments
       x-eov-operation-handler: routes/projects
       responses:
         '200':
@@ -875,7 +889,7 @@ paths:
       summary: Get samples under a project
       description: Get all samples under a project
       operationId: getProjectSamples
-      x-eov-operation-id: 'samples#get'
+      x-eov-operation-id: samples#get
       x-eov-operation-handler: routes/samples
       responses:
         '200':
@@ -914,7 +928,7 @@ paths:
     put:
       summary: Update samples
       operationId: updateSamples
-      x-eov-operation-id: 'samples#update'
+      x-eov-operation-id: samples#update
       x-eov-operation-handler: routes/samples
       responses:
         '200':
@@ -953,7 +967,7 @@ paths:
     delete:
       summary: Remove samples
       operationId: removeSamples
-      x-eov-operation-id: 'samples#remove'
+      x-eov-operation-id: samples#remove
       x-eov-operation-handler: routes/samples
       responses:
         '200':
@@ -1010,7 +1024,7 @@ paths:
     get:
       summary: Get the list of projects
       operationId: getProjects
-      x-eov-operation-id: 'projects#get'
+      x-eov-operation-id: projects#get
       x-eov-operation-handler: routes/projects
       description: Get the projects
       responses:

--- a/src/specs/api.yaml
+++ b/src/specs/api.yaml
@@ -635,9 +635,8 @@ paths:
             application/json:
               schema:
                 type: object
-                properties:
-                  paramsHash:
-                    type: string
+                properties: {}
+
       description: This path will create a new pipeline that can run a state machine with gem2s tasks.
       requestBody:
         content:

--- a/src/specs/models/GEM2SResponse.v1.yaml
+++ b/src/specs/models/GEM2SResponse.v1.yaml
@@ -1,33 +1,32 @@
 title: GEM2S response
 description: This is the format the gem2s clients communicate the result of a gem2s run.
-type: object
 properties:
-  oneOf:
-    - experimentId:
-        type: string
-      taskName:
-        type: string
-      oneOf:
-        - item:
-            $ref: ./api-body-schemas/Experiment.v1.yaml
-          table:
-            type: string
-            pattern: 'experiments'
-        - item:
-            $ref: ./api-body-schemas/Samples.v1.yaml
-          table:
-            type: string
-            pattern: 'samples'
+    experimentId:
+      type: string
+      description: The ID of the experiment GEM2s was called against.
+    taskName:
+      type: string
+      description: The name of the task that was excecuted
+    authJWT:
+      type: string
+      description: A Bearer-style HTTP authentication token passed by the user that ran GEM2S.
+    processingConfig:
+      $ref: './ProcessingConfig.v1.yaml#/properties/processingConfig'
+    meta:
+      type: object
+    table:
+      type: string
+    response:
+      type: object
       required:
-        - experimentId
-        - taskName
-    - response:
-        type: object
-        properties:
-          error:
-            description: "Whether there's been an error."
-            oneOf:
-              - type: string
-              - type: boolean
-          required: 
-            - error
+        - error
+      description: Object storing non-typical response information.
+      properties:
+        error:
+          oneOf:
+            - type: string
+            - type: boolean
+          description: Whether or not an error occurred or a message describing the error.
+required:
+  - experimentId
+type: object

--- a/tests/api/route-services/__snapshots__/gem2s.test.js.snap
+++ b/tests/api/route-services/__snapshots__/gem2s.test.js.snap
@@ -1,8 +1,37 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`gem2s gem2sResponse - Should return message if message is valid 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "ExperimentUpdates-1234",
+      Object {
+        "experimentId": "1234",
+        "status": Object {
+          "gem2s": Object {
+            "completedSteps": Array [],
+            "startDate": null,
+            "status": "SUCCEEDED",
+            "stopDate": null,
+          },
+        },
+        "taskName": "downloadGem",
+        "type": "gem2s",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;
+
 exports[`gem2s generateGem2sParams - Should generate GEM2S taskParams correctly 1`] = `
 Object {
-  "authJWT": "mockAuthJwt",
+  "authJWT": "mockAuthJwtToken",
   "experimentName": "New experiment",
   "input": Object {
     "type": "10x",
@@ -16,6 +45,36 @@ Object {
   "sampleNames": Array [
     "Sample 1",
     "Sample 2",
+  ],
+}
+`;
+
+exports[`gem2s sendUpdateToSubscribed - Should send update if payloads are correct 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "ExperimentUpdates-1234",
+      Object {
+        "authJWT": "Bearer mockAuthJwtToken",
+        "experimentId": "experimentId",
+        "status": Object {
+          "gem2s": Object {
+            "completedSteps": Array [],
+            "startDate": null,
+            "status": "SUCCEEDED",
+            "stopDate": null,
+          },
+        },
+        "taskName": "downloadGem",
+        "type": "gem2s",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
   ],
 }
 `;

--- a/tests/api/route-services/__snapshots__/gem2s.test.js.snap
+++ b/tests/api/route-services/__snapshots__/gem2s.test.js.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`gem2sCreate Should generate GEM2S taskParams correctly 1`] = `
+Object {
+  "authJWT": "mockAuthJwt",
+  "experimentName": "New experiment",
+  "input": Object {
+    "type": "10x",
+  },
+  "organism": null,
+  "projectId": "project-2",
+  "sampleIds": Array [
+    "sample-1",
+    "sample-2",
+  ],
+  "sampleNames": Array [
+    "Sample 1",
+    "Sample 2",
+  ],
+}
+`;

--- a/tests/api/route-services/__snapshots__/gem2s.test.js.snap
+++ b/tests/api/route-services/__snapshots__/gem2s.test.js.snap
@@ -1,12 +1,72 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`gem2s gem2sReponse - Pass on error message properly 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "ExperimentUpdates-abcd1234",
+      Object {
+        "experimentId": "abcd1234",
+        "response": Object {
+          "error": "some unknwon error",
+        },
+        "status": Object {
+          "gem2s": Object {
+            "completedSteps": Array [],
+            "startDate": null,
+            "status": "SUCCEEDED",
+            "stopDate": null,
+          },
+        },
+        "type": "gem2s",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;
+
 exports[`gem2s gem2sResponse - Should return message if message is valid 1`] = `
 [MockFunction] {
   "calls": Array [
     Array [
-      "ExperimentUpdates-1234",
+      "ExperimentUpdates-abcd1234",
       Object {
-        "experimentId": "1234",
+        "experimentId": "abcd1234",
+        "status": Object {
+          "gem2s": Object {
+            "completedSteps": Array [],
+            "startDate": null,
+            "status": "SUCCEEDED",
+            "stopDate": null,
+          },
+        },
+        "taskName": "downloadGem",
+        "type": "gem2s",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;
+
+exports[`gem2s gem2sResponse - Should return message if message is valid 2`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "ExperimentUpdates-abcd1234",
+      Object {
+        "experimentId": "abcd1234",
         "status": Object {
           "gem2s": Object {
             "completedSteps": Array [],
@@ -53,7 +113,7 @@ exports[`gem2s sendUpdateToSubscribed - Should send update if payloads are corre
 [MockFunction] {
   "calls": Array [
     Array [
-      "ExperimentUpdates-1234",
+      "ExperimentUpdates-abcd1234",
       Object {
         "authJWT": "Bearer mockAuthJwtToken",
         "experimentId": "experimentId",

--- a/tests/api/route-services/__snapshots__/gem2s.test.js.snap
+++ b/tests/api/route-services/__snapshots__/gem2s.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`gem2sCreate Should generate GEM2S taskParams correctly 1`] = `
+exports[`gem2s generateGem2sParams - Should generate GEM2S taskParams correctly 1`] = `
 Object {
   "authJWT": "mockAuthJwt",
   "experimentName": "New experiment",

--- a/tests/api/route-services/gem2s.test.js
+++ b/tests/api/route-services/gem2s.test.js
@@ -64,7 +64,7 @@ const mockGem2sParamsBackendCall = (
   };
 };
 
-const experimentId = '1234';
+const experimentId = 'abcd1234';
 const mockAuthJwt = 'mockAuthJwtToken';
 
 describe('gem2s', () => {
@@ -135,19 +135,97 @@ describe('gem2s', () => {
       },
     };
 
-    const validMessageNoTaskName = {
+    const validMessage = {
       taskName: 'downloadGem',
       experimentId,
-      authJWT: 'Bearer mockAuthJwtToken',
     };
 
-    await gem2sService.gem2sResponse(mockIo, validMessageNoTaskName);
+    await gem2sService.gem2sResponse(mockIo, validMessage);
 
     const emitParamsChannel = mockedSocketsEmit.mock.calls[0][0];
     expect(mockedSocketsEmit).toHaveBeenCalled();
 
     // Emitted to the correct channel
     expect(emitParamsChannel).toMatch(experimentId);
+    expect(mockedSocketsEmit).toMatchSnapshot();
+  });
+
+
+  it('gem2sResponse - Should return message if message is valid', async () => {
+    const gem2sService = new Gem2sService();
+
+    const mockedSocketsEmit = jest.fn();
+    const mockIo = {
+      sockets: {
+        emit: mockedSocketsEmit,
+      },
+    };
+
+    const validMessage = {
+      taskName: 'downloadGem',
+      experimentId,
+    };
+
+    await gem2sService.gem2sResponse(mockIo, validMessage);
+
+    const emitParamsChannel = mockedSocketsEmit.mock.calls[0][0];
+    expect(mockedSocketsEmit).toHaveBeenCalled();
+
+    // Emitted to the correct channel
+    expect(emitParamsChannel).toMatch(experimentId);
+    expect(mockedSocketsEmit).toMatchSnapshot();
+  });
+
+
+  it('gem2sResponse - Should throw an error if message is invalid', async () => {
+    const gem2sService = new Gem2sService();
+
+    const mockedSocketsEmit = jest.fn();
+    const mockIo = {
+      sockets: {
+        emit: mockedSocketsEmit,
+      },
+    };
+
+    const InvalidMessage = {
+      taskName: 'downloadGem',
+    };
+
+    await expect(gem2sService.gem2sResponse(mockIo, InvalidMessage)).rejects.toBeInstanceOf(Error);
+
+    expect(mockedSocketsEmit).not.toHaveBeenCalled();
+  });
+
+  it('gem2sReponse - Pass on error message properly', async () => {
+    const gem2sService = new Gem2sService();
+
+    const mockedSocketsEmit = jest.fn();
+    const mockIo = {
+      sockets: {
+        emit: mockedSocketsEmit,
+      },
+    };
+
+    const errorText = 'some unknwon error';
+
+    const errorMessage = {
+      experimentId,
+      response: {
+        error: errorText,
+      },
+    };
+
+    await gem2sService.gem2sResponse(mockIo, errorMessage);
+
+    const emitParamsChannel = mockedSocketsEmit.mock.calls[0][0];
+    const errorMessge = mockedSocketsEmit.mock.calls[0][1].response.error;
+
+    expect(mockedSocketsEmit).toHaveBeenCalled();
+
+    // Emitted to the correct channel
+    expect(emitParamsChannel).toMatch(experimentId);
+    expect(errorMessge).toEqual(errorText);
+
     expect(mockedSocketsEmit).toMatchSnapshot();
   });
 });

--- a/tests/api/route-services/gem2s.test.js
+++ b/tests/api/route-services/gem2s.test.js
@@ -1,20 +1,27 @@
-const constants = require('../../../src/api/general-services/pipeline-manage/constants');
-
 const ExperimentService = require('../../../src/api/route-services/experiment');
 const SamplesService = require('../../../src/api/route-services/samples');
 const ProjectsService = require('../../../src/api/route-services/projects');
-const getPipelineStatus = require('../../../src/api/general-services/pipeline-status');
 
 const Gem2sService = require('../../../src/api/route-services/gem2s');
 
-const {
-  RUNNING, SUCCEEDED, NOT_CREATED, FAILED, TIMED_OUT, GEM2S_PROCESS_NAME, QC_PROCESS_NAME,
-} = constants;
+const { OK } = require('../../../src/utils/responses');
+
+
+const newGem2sHandle = {
+  stateMachineArn: 'arnSM_gem2s',
+  executionArn: 'arnE_sem2s',
+  paramsHash: 'randomHash',
+};
+
+jest.mock('../../../src/api/route-services/experiment');
+jest.mock('../../../src/api/route-services/samples');
+jest.mock('../../../src/api/route-services/projects');
+jest.mock('../../../src/api/general-services/pipeline-status');
 
 const mockGem2sParamsBackendCall = (
-  customProjectResponse = null,
-  customSamplesResponse = null,
-  customMetadataResponse = null,
+  customProjectResponse = {},
+  customSamplesResponse = {},
+  customMetadataResponse = {},
 ) => {
   const projectResponse = {
     projectId: 'project-2',
@@ -43,6 +50,7 @@ const mockGem2sParamsBackendCall = (
   ExperimentService.mockImplementation(() => ({
     getExperimentData: jest.fn()
       .mockImplementationOnce(() => Promise.resolve(projectResponse)),
+    saveGem2sHandle: jest.fn(),
   }));
 
   SamplesService.mockImplementation(() => ({
@@ -56,302 +64,50 @@ const mockGem2sParamsBackendCall = (
   }));
 };
 
-jest.mock('../../../src/api/route-services/experiment');
-jest.mock('../../../src/api/route-services/samples');
-jest.mock('../../../src/api/route-services/projects');
-jest.mock('../../../src/api/general-services/pipeline-status');
+jest.mock('../../../src/api/general-services/pipeline-manage', () => ({
+  createGem2SPipeline: jest.fn(() => Promise.resolve({
+    stateMachineArn: 'arnSM_gem2s',
+    executionArn: 'arnE_sem2s',
+    paramsHash: 'randomHash',
+  })),
+}));
 
-describe('gem2sShouldRun', () => {
-  const mockEmptyHandles = {
-    [GEM2S_PROCESS_NAME]: {
-      stateMachineArn: null,
-      executionArn: null,
-    },
-    [QC_PROCESS_NAME]: {
-      stateMachineArn: null,
-      executionArn: null,
-    },
-  };
+const experimentId = '1234';
 
-  const mockFilledHandles = {
-    [GEM2S_PROCESS_NAME]: {
-      stateMachineArn: 'arnSM_gem2s',
-      executionArn: 'arnE_sem2s',
-      paramsHash: 'sameHash',
-    },
-    [QC_PROCESS_NAME]: {
-      stateMachineArn: 'arnSM_qc',
-      executionArn: 'arnE_qc',
-    },
-  };
-
+describe('gem2sCreate', () => {
   beforeEach(() => {
-    ExperimentService.mockClear();
+    jest.resetModules();
   });
 
-  it('returns true when gem2s is not created yet', async () => {
-    ExperimentService.mockImplementation(() => ({
-      getPipelinesHandles: () => Promise.resolve(mockEmptyHandles),
-    }));
-
-    getPipelineStatus.mockImplementation(
-      () => Promise.resolve(
-        { [GEM2S_PROCESS_NAME]: { status: NOT_CREATED } },
-      ),
-    );
-
-    const shouldRun = await Gem2sService.gem2sShouldRun('experimentId', null);
-
-    expect(shouldRun).toEqual(true);
-  });
-
-  it('returns true when gem2s failed', async () => {
-    ExperimentService.mockImplementation(() => ({
-      getPipelinesHandles: () => Promise.resolve(mockFilledHandles),
-    }));
-
-    getPipelineStatus.mockImplementation(
-      () => Promise.resolve(
-        { [GEM2S_PROCESS_NAME]: { status: FAILED } },
-      ),
-    );
-
-    const shouldRun = await Gem2sService.gem2sShouldRun('experimentId', 'newHash');
-
-    expect(shouldRun).toEqual(true);
-  });
-
-  it('returns true when gem2s failed', async () => {
-    ExperimentService.mockImplementation(() => ({
-      getPipelinesHandles: () => Promise.resolve(mockFilledHandles),
-    }));
-
-    getPipelineStatus.mockImplementation(
-      () => Promise.resolve(
-        { [GEM2S_PROCESS_NAME]: { status: FAILED } },
-      ),
-    );
-
-    const shouldRun = await Gem2sService.gem2sShouldRun('experimentId', 'newHash');
-
-    expect(shouldRun).toEqual(true);
-  });
-
-  it('returns true when gem2s timed out', async () => {
-    ExperimentService.mockImplementation(() => ({
-      getPipelinesHandles: () => Promise.resolve(mockFilledHandles),
-    }));
-
-    getPipelineStatus.mockImplementation(
-      () => Promise.resolve(
-        { [GEM2S_PROCESS_NAME]: { status: TIMED_OUT } },
-      ),
-    );
-
-    const shouldRun = await Gem2sService.gem2sShouldRun('experimentId', 'newHash');
-
-    expect(shouldRun).toEqual(true);
-  });
-
-  it('returns true when gem2s timed out', async () => {
-    ExperimentService.mockImplementation(() => ({
-      getPipelinesHandles: () => Promise.resolve(mockFilledHandles),
-    }));
-
-    getPipelineStatus.mockImplementation(
-      () => Promise.resolve(
-        { [GEM2S_PROCESS_NAME]: { status: TIMED_OUT } },
-      ),
-    );
-
-    const shouldRun = await Gem2sService.gem2sShouldRun('experimentId', 'newHash');
-
-    expect(shouldRun).toEqual(true);
-  });
-
-  it('returns true when gem2s aborted', async () => {
-    ExperimentService.mockImplementation(() => ({
-      getPipelinesHandles: () => Promise.resolve(mockFilledHandles),
-    }));
-
-    getPipelineStatus.mockImplementation(
-      () => Promise.resolve(
-        { [GEM2S_PROCESS_NAME]: { status: TIMED_OUT } },
-      ),
-    );
-
-    const shouldRun = await Gem2sService.gem2sShouldRun('experimentId', 'newHash');
-
-    expect(shouldRun).toEqual(true);
-  });
-
-  it('returns false when gem2s is running', async () => {
-    ExperimentService.mockImplementation(() => ({
-      getPipelinesHandles: () => Promise.resolve(mockFilledHandles),
-    }));
-
-    getPipelineStatus.mockImplementation(
-      () => Promise.resolve(
-        { [GEM2S_PROCESS_NAME]: { status: RUNNING } },
-      ),
-    );
-
-    const shouldRun = await Gem2sService.gem2sShouldRun('experimentId', 'newHash');
-
-    expect(shouldRun).toEqual(false);
-  });
-
-  it('returns false when gem2s succeeded but has the same params hash as the latest run', async () => {
-    ExperimentService.mockImplementation(() => ({
-      getPipelinesHandles: () => Promise.resolve(mockFilledHandles),
-    }));
-
-    getPipelineStatus.mockImplementation(
-      () => Promise.resolve(
-        { [GEM2S_PROCESS_NAME]: { status: SUCCEEDED } },
-      ),
-    );
-
-    const shouldRun = await Gem2sService.gem2sShouldRun('experimentId', 'sameHash');
-
-    expect(shouldRun).toEqual(false);
-  });
-
-  it('returns true when gem2s succeeded and has a different params hash as the latest run', async () => {
-    ExperimentService.mockImplementation(() => ({
-      getPipelinesHandles: () => Promise.resolve(mockFilledHandles),
-    }));
-
-    getPipelineStatus.mockImplementation(
-      () => Promise.resolve(
-        { [GEM2S_PROCESS_NAME]: { status: SUCCEEDED } },
-      ),
-    );
-
-    const shouldRun = await Gem2sService.gem2sShouldRun('experimentId', 'differentHash');
-
-    expect(shouldRun).toEqual(true);
-  });
-
-
-  it('generateGem2sTaskParams returns the same hash param if passed diferent information on non-vital fields', async () => {
-    ExperimentService.mockImplementation(() => ({
-      getExperimentData: jest.fn()
-        .mockImplementationOnce(() => Promise.resolve({
-          projectId: 'project-1',
-          experimentName: 'New experiment',
-          meta: {
-            organism: null,
-            type: '10x',
-          },
-          sampleIds: ['sample-2', 'sample-1'],
-        })),
-    }));
-
-    SamplesService.mockImplementation(() => ({
-      getSamplesByExperimentId: jest.fn()
-        .mockImplementationOnce(() => Promise.resolve({
-          samples: {
-            'sample-1': { name: 'Sample 1' },
-            'sample-2': { name: 'Sample 2' },
-          },
-        })),
-    }));
-
-    ProjectsService.mockImplementation(() => ({
-      getProject: jest.fn()
-        .mockImplementationOnce(() => Promise.resolve({ metadataKeys: [] })),
-    }));
-
-    const { taskParams: task1, hashParams: hash1 } = await Gem2sService.generateGem2sParams('experimentId');
-
-    ExperimentService.mockImplementation(() => ({
-      getExperimentData: jest.fn()
-        .mockImplementationOnce(() => Promise.resolve({
-          projectId: 'project-2', // Changed
-          experimentName: 'Another new experiment', // Changed
-          meta: {
-            organism: null,
-            type: '10x',
-          },
-          sampleIds: ['sample-1', 'sample-2'],
-        })),
-    }));
-
-    SamplesService.mockImplementation(() => ({
-      getSamplesByExperimentId: jest.fn()
-        .mockImplementationOnce(() => Promise.resolve({
-          samples: {
-            'sample-1': { name: 'Sample 1' },
-            'sample-2': { name: 'Sample 2' },
-          },
-        })),
-    }));
-
-    ProjectsService.mockImplementation(() => ({
-      getProject: jest.fn()
-        .mockImplementationOnce(() => Promise.resolve({ metadataKeys: [] })),
-    }));
-
-
-    const { taskParams: task2, hashParams: hash2 } = await Gem2sService.generateGem2sParams('experimentId');
-
-    expect(hash1).toEqual(hash2);
-  });
-
-  it('generateGem2sTaskParams - different sample order should return the same hash', async () => {
+  it('GEM2S should run when passed shouldRun is true', async () => {
     mockGem2sParamsBackendCall();
 
-    const { taskParams: task1, hashParams: hash1 } = await Gem2sService.generateGem2sParams('experimentId');
+    const requestBody = {
+      gem2sHash: 'gem2sHash1234',
+      shouldRun: true,
+    };
 
-    mockGem2sParamsBackendCall({
-      sampleIds: ['sample-1', 'sample-2'], // Different sample order
-    });
-
-    const { taskParams: task2, hashParams: hash2 } = await Gem2sService.generateGem2sParams('experimentId');
-
-    expect(hash1).toEqual(hash2);
+    const newHandle = await Gem2sService.gem2sCreate(experimentId, requestBody);
+    expect(newHandle).toEqual(newGem2sHandle);
   });
 
-  it('generateGem2sTaskParams returns different hash param if passed diferent information on sample names', async () => {
-    mockGem2sParamsBackendCall();
+  it('GEM2S should not run when passed shouldRun is false', async () => {
+    const requestBody = {
+      gem2sHash: 'gem2sHash1234',
+      shouldRun: false,
+    };
 
-    const { taskParams: task1, hashParams: hash1 } = await Gem2sService.generateGem2sParams('experimentId');
+    const response = await Gem2sService.gem2sCreate(experimentId, requestBody);
 
-    mockGem2sParamsBackendCall(
-      null,
-      {
-        samples: {
-          'sample-1': { name: 'Sample A' },
-          'sample-2': { name: 'Sample B' }, // Different sample names
-        },
-      },
-      null,
-    );
-
-    const { taskParams: task2, hashParams: hash2 } = await Gem2sService.generateGem2sParams('experimentId');
-
-    expect(hash1).not.toEqual(hash2);
+    expect(response).toEqual(OK());
   });
 
-  it('generateGem2sTaskParams returns different hash param if passed diferent information on metadata', async () => {
+  it('Should generate GEM2S taskParams correctly', async () => {
     mockGem2sParamsBackendCall();
 
-    const { taskParams: task1, hashParams: hash1 } = await Gem2sService.generateGem2sParams('experimentId');
+    const mockAuthJwt = 'mockAuthJwt';
+    const taskParams = await Gem2sService.generateGem2sParams(experimentId, mockAuthJwt);
 
-    mockGem2sParamsBackendCall(
-      { metadataKeys: ['meta-1'] },
-      {
-        samples: {
-          'sample-1': { name: 'Sample 1', metadata: { 'meta-1': 'Meta A' } },
-          'sample-2': { name: 'Sample 2', metadata: { 'meta-1': 'Meta B' } },
-        },
-      },
-      { metadataKeys: ['meta-1'] },
-    );
-
-    const { taskParams: task2, hashParams: hash2 } = await Gem2sService.generateGem2sParams('experimentId');
-
-    expect(hash1).not.toEqual(hash2);
+    expect(taskParams).toMatchSnapshot();
   });
 });

--- a/tests/api/route-services/gem2s.test.js
+++ b/tests/api/route-services/gem2s.test.js
@@ -1,17 +1,9 @@
+/* eslint-disable arrow-body-style */
+/* eslint-disable global-require */
 const ExperimentService = require('../../../src/api/route-services/experiment');
+const Gem2sService = require('../../../src/api/route-services/gem2s');
 const SamplesService = require('../../../src/api/route-services/samples');
 const ProjectsService = require('../../../src/api/route-services/projects');
-
-const Gem2sService = require('../../../src/api/route-services/gem2s');
-
-const { OK } = require('../../../src/utils/responses');
-
-
-const newGem2sHandle = {
-  stateMachineArn: 'arnSM_gem2s',
-  executionArn: 'arnE_sem2s',
-  paramsHash: 'randomHash',
-};
 
 jest.mock('../../../src/api/route-services/experiment');
 jest.mock('../../../src/api/route-services/samples');
@@ -73,16 +65,59 @@ jest.mock('../../../src/api/general-services/pipeline-manage', () => ({
 }));
 
 const experimentId = '1234';
+const mockAuthJwt = 'mockAuthJwt';
 
-describe('gem2sCreate', () => {
+describe('gem2s', () => {
   beforeEach(() => {
     jest.resetModules();
   });
 
-  it('Should generate GEM2S taskParams correctly', async () => {
+  it('gem2sCreate - Creates new GEM2S handles and save them to database', async () => {
+    const mockBody = {
+      paramsHash: 'gem2s-params-hash',
+    };
+
+    const { createGem2SPipeline } = require('../../../src/api/general-services/pipeline-manage');
+
+    jest.mock('../../../src/api/route-services/gem2s', () => {
+      const OriginalClass = jest.requireActual('../../../src/api/route-services/gem2s');
+      OriginalClass.prototype.generateGem2sParams = jest.fn(() => ({}));
+      const originalClass = new OriginalClass();
+
+      return function () {
+        return originalClass;
+      };
+    });
+
+    const mockSaveGem2sHandle = jest.fn();
+
+    jest.mock('../../../src/api/route-services/experiment', () => {
+      return jest.fn().mockImplementation(() => {
+        return { saveGem2sHandle: mockSaveGem2sHandle };
+      });
+    });
+
+    const MockedGem2sService = require('../../../src/api/route-services/gem2s');
+
+    const gem2sService = new MockedGem2sService();
+
+    await gem2sService.gem2sCreate(experimentId, mockBody, mockAuthJwt);
+
+    // Create new gem2sParamsHash
+    expect(gem2sService.generateGem2sParams).toHaveBeenCalled();
+
+    // Create new handles
+    expect(createGem2SPipeline).toHaveBeenCalled();
+
+    console.log('*** Mocked service', mockSaveGem2sHandle);
+
+    // // Create new handles
+    expect(mockSaveGem2sHandle).toHaveBeenCalled();
+  });
+
+  it('generateGem2sParams - Should generate GEM2S taskParams correctly', async () => {
     mockGem2sParamsBackendCall();
 
-    const mockAuthJwt = 'mockAuthJwt';
     const taskParams = await Gem2sService.generateGem2sParams(experimentId, mockAuthJwt);
 
     expect(taskParams).toMatchSnapshot();

--- a/tests/api/route-services/gem2s.test.js
+++ b/tests/api/route-services/gem2s.test.js
@@ -79,29 +79,6 @@ describe('gem2sCreate', () => {
     jest.resetModules();
   });
 
-  it('GEM2S should run when passed shouldRun is true', async () => {
-    mockGem2sParamsBackendCall();
-
-    const requestBody = {
-      gem2sHash: 'gem2sHash1234',
-      shouldRun: true,
-    };
-
-    const newHandle = await Gem2sService.gem2sCreate(experimentId, requestBody);
-    expect(newHandle).toEqual(newGem2sHandle);
-  });
-
-  it('GEM2S should not run when passed shouldRun is false', async () => {
-    const requestBody = {
-      gem2sHash: 'gem2sHash1234',
-      shouldRun: false,
-    };
-
-    const response = await Gem2sService.gem2sCreate(experimentId, requestBody);
-
-    expect(response).toEqual(OK());
-  });
-
   it('Should generate GEM2S taskParams correctly', async () => {
     mockGem2sParamsBackendCall();
 

--- a/tests/api/route-services/gem2s.test.js
+++ b/tests/api/route-services/gem2s.test.js
@@ -80,9 +80,7 @@ describe('gem2s', () => {
       paramsHash: 'gem2s-params-hash',
     };
 
-    const gem2sService = new Gem2sService();
-
-    await gem2sService.gem2sCreate(experimentId, mockBody, mockAuthJwt);
+    await Gem2sService.gem2sCreate(experimentId, mockBody, mockAuthJwt);
 
     // Create new handles
     expect(createGem2SPipeline).toHaveBeenCalled();
@@ -100,8 +98,6 @@ describe('gem2s', () => {
   });
 
   it('sendUpdateToSubscribed - Should send update if payloads are correct', async () => {
-    const gem2sService = new Gem2sService();
-
     const mockedSocketsEmit = jest.fn();
     const mockIo = {
       sockets: {
@@ -115,7 +111,7 @@ describe('gem2s', () => {
       authJWT: 'Bearer mockAuthJwtToken',
     };
 
-    await gem2sService.constructor.sendUpdateToSubscribed(experimentId, parsedMessage, mockIo);
+    await Gem2sService.sendUpdateToSubscribed(experimentId, parsedMessage, mockIo);
 
     const emitParamsChannel = mockedSocketsEmit.mock.calls[0][0];
     expect(mockedSocketsEmit).toHaveBeenCalled();
@@ -126,8 +122,6 @@ describe('gem2s', () => {
   });
 
   it('gem2sResponse - Should return message if message is valid', async () => {
-    const gem2sService = new Gem2sService();
-
     const mockedSocketsEmit = jest.fn();
     const mockIo = {
       sockets: {
@@ -140,7 +134,7 @@ describe('gem2s', () => {
       experimentId,
     };
 
-    await gem2sService.gem2sResponse(mockIo, validMessage);
+    await Gem2sService.gem2sResponse(mockIo, validMessage);
 
     const emitParamsChannel = mockedSocketsEmit.mock.calls[0][0];
     expect(mockedSocketsEmit).toHaveBeenCalled();
@@ -152,8 +146,6 @@ describe('gem2s', () => {
 
 
   it('gem2sResponse - Should return message if message is valid', async () => {
-    const gem2sService = new Gem2sService();
-
     const mockedSocketsEmit = jest.fn();
     const mockIo = {
       sockets: {
@@ -166,7 +158,7 @@ describe('gem2s', () => {
       experimentId,
     };
 
-    await gem2sService.gem2sResponse(mockIo, validMessage);
+    await Gem2sService.gem2sResponse(mockIo, validMessage);
 
     const emitParamsChannel = mockedSocketsEmit.mock.calls[0][0];
     expect(mockedSocketsEmit).toHaveBeenCalled();
@@ -178,8 +170,6 @@ describe('gem2s', () => {
 
 
   it('gem2sResponse - Should throw an error if message is invalid', async () => {
-    const gem2sService = new Gem2sService();
-
     const mockedSocketsEmit = jest.fn();
     const mockIo = {
       sockets: {
@@ -191,14 +181,12 @@ describe('gem2s', () => {
       taskName: 'downloadGem',
     };
 
-    await expect(gem2sService.gem2sResponse(mockIo, InvalidMessage)).rejects.toBeInstanceOf(Error);
+    await expect(Gem2sService.gem2sResponse(mockIo, InvalidMessage)).rejects.toBeInstanceOf(Error);
 
     expect(mockedSocketsEmit).not.toHaveBeenCalled();
   });
 
   it('gem2sReponse - Pass on error message properly', async () => {
-    const gem2sService = new Gem2sService();
-
     const mockedSocketsEmit = jest.fn();
     const mockIo = {
       sockets: {
@@ -215,7 +203,7 @@ describe('gem2s', () => {
       },
     };
 
-    await gem2sService.gem2sResponse(mockIo, errorMessage);
+    await Gem2sService.gem2sResponse(mockIo, errorMessage);
 
     const emitParamsChannel = mockedSocketsEmit.mock.calls[0][0];
     const errorMessge = mockedSocketsEmit.mock.calls[0][1].response.error;


### PR DESCRIPTION
# Background
#### Link to issue 

https://biomage.atlassian.net/browse/BIOMAGE-1184

#### Link to staging deployment URL 

in UI PR

#### Links to any Pull Requests related to this

UI - https://github.com/biomage-ltd/ui/pull/489

#### Anything else the reviewers should know about the changes here

Return gem2s HashParams in backendStatus

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging
- [ ] Passed integration tests 

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
