### PR TITLE
Handle scan limit

### DIFF
--- a/src/api/route-services/projects.js
+++ b/src/api/route-services/projects.js
@@ -137,9 +137,6 @@ class ProjectsService {
       },
     };
 
-    console.log('== PARAMS');
-    console.log(params);
-
     const data = await safeBatchGetItem(dynamodb, params);
 
     const existingProjectIds = new Set(data.Responses[this.tableName].map((entry) => {

--- a/src/api/route-services/projects.js
+++ b/src/api/route-services/projects.js
@@ -96,6 +96,9 @@ class ProjectsService {
 
     const response = await dynamodb.scan(params).promise();
 
+    console.log('Scan response :');
+    console.log(response);
+
     if (!response.Items.length) {
       return [];
     }
@@ -122,6 +125,9 @@ class ProjectsService {
         },
       },
     };
+
+    console.log('== PARAMS');
+    console.log(params);
 
     const data = await safeBatchGetItem(dynamodb, params);
 


### PR DESCRIPTION
# Background
#### Link to issue 

https://this-is-biomage.slack.com/archives/C014YMUT6GN/p1631604849028800 

The current way we get a user's list of projects is by : 
1. Fetching all `experimentIds`
2. Filtering these experiments for those which includes the user's `user_id` in `rbac_can_write`
3. Fetching `projects` according to these experiments

The Issue appears because on step no 1 because `scan` operation used to get all the experiments exceeds capacity.

#### Link to staging deployment URL 

https://ui-agi-api226.scp-staging.biomage.net/

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [x] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [x] Deployed to staging
- [ ] Passed integration tests 

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
