### PR TITLE
[BIOMAGE-1383] UI shows old backend status state before rerunning gem2s.

### DIFF
--- a/src/api/general-services/pipeline-manage/constants.js
+++ b/src/api/general-services/pipeline-manage/constants.js
@@ -10,6 +10,7 @@ const FAILED = 'FAILED';
 const TIMED_OUT = 'TIMED_OUT';
 const ABORTED = 'ABORTED';
 const SUCCEEDED = 'SUCCEEDED';
+const NEEDS_RERUN = 'NEEDS_RERUN';
 
 // Custom defined statuses defined in the API
 const NOT_CREATED = 'NOT_CREATED';
@@ -22,6 +23,7 @@ const EXECUTION_DOES_NOT_EXIST = 'ExecutionDoesNotExist';
 const ACCESS_DENIED = 'AccessDeniedException';
 
 module.exports = {
+  NEEDS_RERUN,
   QC_PROCESS_NAME,
   GEM2S_PROCESS_NAME,
   OLD_QC_NAME_TO_BE_REMOVED,

--- a/src/api/general-services/pipeline-status.js
+++ b/src/api/general-services/pipeline-status.js
@@ -1,4 +1,5 @@
 const _ = require('lodash');
+const crypto = require('crypto');
 const AWS = require('../../utils/requireAWS');
 const ExperimentService = require('../route-services/experiment');
 const config = require('../../config');

--- a/src/api/general-services/pipeline-status.js
+++ b/src/api/general-services/pipeline-status.js
@@ -5,7 +5,6 @@ const ExperimentService = require('../route-services/experiment');
 const config = require('../../config');
 const getLogger = require('../../utils/getLogger');
 const pipelineConstants = require('./pipeline-manage/constants');
-const constants = require('./pipeline-manage/constants');
 
 const logger = getLogger();
 
@@ -234,7 +233,7 @@ const getPipelineStatus = async (experimentId, processName) => {
   completedSteps = getStepsFromExecutionHistory(events);
 
   let { status } = execution;
-  if (processName === constants.GEM2S_PROCESS_NAME && status === pipelineConstants.SUCCEEDED) {
+  if (processName === pipelineConstants.GEM2S_PROCESS_NAME && status === pipelineConstants.SUCCEEDED) {
     const Gem2sService = require('../route-services/gem2s');
     const { hashParams } = await Gem2sService.generateGem2sParams(experimentId);
     const paramsHash = crypto
@@ -243,7 +242,7 @@ const getPipelineStatus = async (experimentId, processName) => {
       .digest('hex');
     const shouldRun = await Gem2sService.gem2sShouldRun(experimentId, paramsHash, status);
     if (shouldRun) {
-      status = constants.NEEDS_RERUN;
+      status = pipelineConstants.NEEDS_RERUN;
       completedSteps = [];
     }
   }

--- a/tests/api/route-services/gem2s.test.js
+++ b/tests/api/route-services/gem2s.test.js
@@ -100,7 +100,7 @@ describe('gem2sShouldRun', () => {
       ),
     );
 
-    const shouldRun = await Gem2sService.gem2sShouldRun('experimentId', null);
+    const shouldRun = await Gem2sService.gem2sShouldRun('experimentId', null, NOT_CREATED);
 
     expect(shouldRun).toEqual(true);
   });
@@ -116,7 +116,7 @@ describe('gem2sShouldRun', () => {
       ),
     );
 
-    const shouldRun = await Gem2sService.gem2sShouldRun('experimentId', 'newHash');
+    const shouldRun = await Gem2sService.gem2sShouldRun('experimentId', 'newHash', FAILED);
 
     expect(shouldRun).toEqual(true);
   });
@@ -132,7 +132,7 @@ describe('gem2sShouldRun', () => {
       ),
     );
 
-    const shouldRun = await Gem2sService.gem2sShouldRun('experimentId', 'newHash');
+    const shouldRun = await Gem2sService.gem2sShouldRun('experimentId', 'newHash', FAILED);
 
     expect(shouldRun).toEqual(true);
   });
@@ -148,7 +148,7 @@ describe('gem2sShouldRun', () => {
       ),
     );
 
-    const shouldRun = await Gem2sService.gem2sShouldRun('experimentId', 'newHash');
+    const shouldRun = await Gem2sService.gem2sShouldRun('experimentId', 'newHash', TIMED_OUT);
 
     expect(shouldRun).toEqual(true);
   });
@@ -164,7 +164,7 @@ describe('gem2sShouldRun', () => {
       ),
     );
 
-    const shouldRun = await Gem2sService.gem2sShouldRun('experimentId', 'newHash');
+    const shouldRun = await Gem2sService.gem2sShouldRun('experimentId', 'newHash', TIMED_OUT);
 
     expect(shouldRun).toEqual(true);
   });
@@ -180,7 +180,7 @@ describe('gem2sShouldRun', () => {
       ),
     );
 
-    const shouldRun = await Gem2sService.gem2sShouldRun('experimentId', 'newHash');
+    const shouldRun = await Gem2sService.gem2sShouldRun('experimentId', 'newHash', TIMED_OUT);
 
     expect(shouldRun).toEqual(true);
   });
@@ -196,7 +196,7 @@ describe('gem2sShouldRun', () => {
       ),
     );
 
-    const shouldRun = await Gem2sService.gem2sShouldRun('experimentId', 'newHash');
+    const shouldRun = await Gem2sService.gem2sShouldRun('experimentId', 'newHash', RUNNING);
 
     expect(shouldRun).toEqual(false);
   });
@@ -212,7 +212,7 @@ describe('gem2sShouldRun', () => {
       ),
     );
 
-    const shouldRun = await Gem2sService.gem2sShouldRun('experimentId', 'sameHash');
+    const shouldRun = await Gem2sService.gem2sShouldRun('experimentId', 'sameHash', SUCCEEDED);
 
     expect(shouldRun).toEqual(false);
   });
@@ -228,7 +228,7 @@ describe('gem2sShouldRun', () => {
       ),
     );
 
-    const shouldRun = await Gem2sService.gem2sShouldRun('experimentId', 'differentHash');
+    const shouldRun = await Gem2sService.gem2sShouldRun('experimentId', 'differentHash', SUCCEEDED);
 
     expect(shouldRun).toEqual(true);
   });


### PR DESCRIPTION
# Background
#### Link to issue 
https://biomage.atlassian.net/secure/RapidBoard.jspa?rapidView=1&projectKey=BIOMAGE&modal=detail&selectedIssue=BIOMAGE-1383
#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging
- [ ] Passed integration tests 

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
