### PR TITLE
Fix lack of selfLink on modern versions of Kubernetes

### DIFF
--- a/src/api/general-services/pipeline-manage/constructors/assign-pod-to-pipeline.js
+++ b/src/api/general-services/pipeline-manage/constructors/assign-pod-to-pipeline.js
@@ -61,7 +61,7 @@ const deleteRunningPods = (context, step) => {
             CertificateAuthority: clusterInfo.certAuthority,
             Endpoint: clusterInfo.endpoint,
             Method: 'DELETE',
-            'Path.$': '$.metadata.selfLink',
+            'Path.$': "States.Format('/api/v1/namespaces/{}/pods/{}', $.metadata.namespace, $.metadata.name)",
           },
           Catch: [
             {
@@ -150,7 +150,7 @@ const assignPodToPipeline = (context, step) => {
             CertificateAuthority: clusterInfo.certAuthority,
             Endpoint: clusterInfo.endpoint,
             Method: 'PATCH',
-            'Path.$': '$.ResponseBody.items[0].metadata.selfLink',
+            'Path.$': "States.Format('/api/v1/namespaces/{}/pods/{}', $.ResponseBody.items[0].metadata.namespace, $.ResponseBody.items[0].metadata.name)",
             RequestBody: {
               metadata: {
                 labels: {

--- a/tests/api/general-services/__snapshots__/pipeline-manage.test.js.snap
+++ b/tests/api/general-services/__snapshots__/pipeline-manage.test.js.snap
@@ -222,7 +222,7 @@ Array [
                   "ClusterName": "biomage-test",
                   "Endpoint": "https://test-endpoint.me/fgh",
                   "Method": "PATCH",
-                  "Path.$": "$.ResponseBody.items[0].metadata.selfLink",
+                  "Path.$": "States.Format('/api/v1/namespaces/{}/pods/{}', $.ResponseBody.items[0].metadata.namespace, $.ResponseBody.items[0].metadata.name)",
                   "RequestBody": Object {
                     "metadata": Object {
                       "labels": Object {
@@ -399,7 +399,7 @@ Array [
                   "ClusterName": "biomage-test",
                   "Endpoint": "https://test-endpoint.me/fgh",
                   "Method": "DELETE",
-                  "Path.$": "$.metadata.selfLink",
+                  "Path.$": "States.Format('/api/v1/namespaces/{}/pods/{}', $.metadata.namespace, $.metadata.name)",
                 },
                 "Resource": "arn:aws:states:::eks:call",
                 "Type": "Task",

--- a/tests/api/general-services/__snapshots__/state-machine-definition.test.js.snap
+++ b/tests/api/general-services/__snapshots__/state-machine-definition.test.js.snap
@@ -178,7 +178,7 @@ exports[`non-tests to document the State Machines - gem2s production 1`] = `
               "CertificateAuthority": "mock-ca",
               "Endpoint": "mock-endpoint",
               "Method": "DELETE",
-              "Path.$": "$.metadata.selfLink"
+              "Path.$": "States.Format('/api/v1/namespaces/{}/pods/{}', $.metadata.namespace, $.metadata.name)"
             },
             "Catch": [
               {
@@ -264,7 +264,7 @@ exports[`non-tests to document the State Machines - gem2s production 1`] = `
               "CertificateAuthority": "mock-ca",
               "Endpoint": "mock-endpoint",
               "Method": "PATCH",
-              "Path.$": "$.ResponseBody.items[0].metadata.selfLink",
+              "Path.$": "States.Format('/api/v1/namespaces/{}/pods/{}', $.ResponseBody.items[0].metadata.namespace, $.ResponseBody.items[0].metadata.name)",
               "RequestBody": {
                 "metadata": {
                   "labels": {
@@ -416,7 +416,7 @@ exports[`non-tests to document the State Machines - gem2s staging 1`] = `
               "CertificateAuthority": "mock-ca",
               "Endpoint": "mock-endpoint",
               "Method": "DELETE",
-              "Path.$": "$.metadata.selfLink"
+              "Path.$": "States.Format('/api/v1/namespaces/{}/pods/{}', $.metadata.namespace, $.metadata.name)"
             },
             "Catch": [
               {
@@ -502,7 +502,7 @@ exports[`non-tests to document the State Machines - gem2s staging 1`] = `
               "CertificateAuthority": "mock-ca",
               "Endpoint": "mock-endpoint",
               "Method": "PATCH",
-              "Path.$": "$.ResponseBody.items[0].metadata.selfLink",
+              "Path.$": "States.Format('/api/v1/namespaces/{}/pods/{}', $.ResponseBody.items[0].metadata.namespace, $.ResponseBody.items[0].metadata.name)",
               "RequestBody": {
                 "metadata": {
                   "labels": {
@@ -840,7 +840,7 @@ exports[`non-tests to document the State Machines - qc production 1`] = `
               "CertificateAuthority": "mock-ca",
               "Endpoint": "mock-endpoint",
               "Method": "DELETE",
-              "Path.$": "$.metadata.selfLink"
+              "Path.$": "States.Format('/api/v1/namespaces/{}/pods/{}', $.metadata.namespace, $.metadata.name)"
             },
             "Catch": [
               {
@@ -926,7 +926,7 @@ exports[`non-tests to document the State Machines - qc production 1`] = `
               "CertificateAuthority": "mock-ca",
               "Endpoint": "mock-endpoint",
               "Method": "PATCH",
-              "Path.$": "$.ResponseBody.items[0].metadata.selfLink",
+              "Path.$": "States.Format('/api/v1/namespaces/{}/pods/{}', $.ResponseBody.items[0].metadata.namespace, $.ResponseBody.items[0].metadata.name)",
               "RequestBody": {
                 "metadata": {
                   "labels": {
@@ -1133,7 +1133,7 @@ exports[`non-tests to document the State Machines - qc staging 1`] = `
               "CertificateAuthority": "mock-ca",
               "Endpoint": "mock-endpoint",
               "Method": "DELETE",
-              "Path.$": "$.metadata.selfLink"
+              "Path.$": "States.Format('/api/v1/namespaces/{}/pods/{}', $.metadata.namespace, $.metadata.name)"
             },
             "Catch": [
               {
@@ -1219,7 +1219,7 @@ exports[`non-tests to document the State Machines - qc staging 1`] = `
               "CertificateAuthority": "mock-ca",
               "Endpoint": "mock-endpoint",
               "Method": "PATCH",
-              "Path.$": "$.ResponseBody.items[0].metadata.selfLink",
+              "Path.$": "States.Format('/api/v1/namespaces/{}/pods/{}', $.ResponseBody.items[0].metadata.namespace, $.ResponseBody.items[0].metadata.name)",
               "RequestBody": {
                 "metadata": {
                   "labels": {


### PR DESCRIPTION
This is a hot-fix that fixes the bug reported by Oliver [here](https://this-is-biomage.slack.com/archives/C0250TDU1PF/p1632776099003200).

`selfLink` as a metadata value is deprecated in k8s 1.20 and removed in 1.21. See https://github.com/kubernetes/enhancements/issues/1164.