### PR TITLE
add prefilter to classifier body schema

### DIFF
--- a/src/api/route-services/__mocks__/experiment.js
+++ b/src/api/route-services/__mocks__/experiment.js
@@ -70,7 +70,7 @@ const mockUpdateProcessingConfig = jest.fn(
           enabled: true,
         },
         readAlignment: { filterSettings: { method: 'absolute_threshold', methodSettings: { absolute_threshold: { bandwidth: -1, filterThreshold: 0.5 } } }, enabled: true },
-        classifier: { filterSettings: { minProbabiliy: 0.8, filterThreshold: -1 }, enabled: true },
+        classifier: { filterSettings: { FDR: 0.05 }, enabled: true, prefiltered: false },
         mitochondrialContent: { filterSettings: { method: 'absolute_threshold', methodSettings: { absolute_threshold: { maxFraction: 0.1, binStep: 0.05 } } }, enabled: true },
         configureEmbedding: { embeddingSettings: { method: 'tsne', methodSettings: { tsne: { perplexity: 30, learningRate: 200 }, umap: { minimumDistance: 0.1, distanceMetric: 'euclidean' } } }, clusteringSettings: { method: 'louvain', methodSettings: { louvain: { resolution: 0.5 } } } },
         numGenesVsNumUmis: {

--- a/src/specs/models/processing-config-bodies/ProcessingConfigClassifier.v1.yaml
+++ b/src/specs/models/processing-config-bodies/ProcessingConfigClassifier.v1.yaml
@@ -6,6 +6,8 @@ properties:
     type: boolean
   auto:
     type: boolean
+  prefiltered:
+    type: boolean
   filterSettings:
     type: object
     properties:

--- a/src/specs/models/processing-config-bodies/ProcessingConfigClassifier.v1.yaml
+++ b/src/specs/models/processing-config-bodies/ProcessingConfigClassifier.v1.yaml
@@ -15,3 +15,4 @@ properties:
         type: number
 required:
   - filterSettings
+  - prefiltered

--- a/tests/api/routes/experiment.test.js
+++ b/tests/api/routes/experiment.test.js
@@ -119,6 +119,16 @@ describe('tests for experiment route', () => {
   it('Updating processing config with a valid data set results in a successful response', async (done) => {
     const newData = [
       {
+        name: 'classifier',
+        body: {
+          enabled: true,
+          prefiltered: false,
+          filterSettings: {
+            FDR: 0.05,
+          },
+        },
+      },
+      {
         name: 'cellSizeDistribution',
         body: {
           enabled: false,


### PR DESCRIPTION
# Background
#### Link to issue 

https://biomage.atlassian.net/browse/BIOMAGE-1494

#### Link to staging deployment URL 

In UI PR

#### Links to any Pull Requests related to this

UI - https://github.com/biomage-ltd/ui/pull/528
API - https://github.com/biomage-ltd/api/pull/242
Pipeline - https://github.com/biomage-ltd/pipeline/pull/178
IAC Migration - https://github.com/biomage-ltd/iac/pull/191

#### Anything else the reviewers should know about the changes here

- Added `prefiltered` as a prop in the classifier schema body

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [X] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [X] Deployed to staging
- [ ] Passed integration tests 

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
