### PR TITLE
[BIOMGE-1057] returning mocked success in production when executionARN does not exist

### DIFF
--- a/src/api/general-services/backend-status.js
+++ b/src/api/general-services/backend-status.js
@@ -3,10 +3,10 @@ const getPipelineStatus = require('./pipeline-status');
 const getWorkerStatus = require('./worker-status');
 
 const getBackendStatus = async (experimentId) => {
-  const [{ qc }, { gem2s }, { worker }] = await Promise.all(
+  const [{ gem2s }, { qc }, { worker }] = await Promise.all(
     [
-      getPipelineStatus(experimentId, constants.QC_PROCESS_NAME),
       getPipelineStatus(experimentId, constants.GEM2S_PROCESS_NAME),
+      getPipelineStatus(experimentId, constants.QC_PROCESS_NAME),
       getWorkerStatus(experimentId)],
   );
 

--- a/src/api/general-services/pipeline-status.js
+++ b/src/api/general-services/pipeline-status.js
@@ -8,50 +8,109 @@ const { getPipelineStepNames } = require('./pipeline-manage/skeletons');
 
 const logger = getLogger();
 
+// TODO: this lists should be computed from the actual state machines skeletons
+const qcPipelineSteps = [
+  'ClassifierFilter',
+  'CellSizeDistributionFilter',
+  'MitochondrialContentFilter',
+  'NumGenesVsNumUmisFilter',
+  'DoubletScoresFilter',
+  'DataIntegration',
+  'ConfigureEmbedding'];
+
+const gem2sPipelineSteps = [
+  'DownloadGem',
+  'PreProcessing',
+  'EmptyDrops',
+  'DoubletScores',
+  'CreateSeurat',
+  'PrepareExperiment',
+  'UploadToAWS'];
+
 // pipelineStepNames are the names of pipeline steps for which we
 // want to report the progress back to the user
 // does not include steps used to initialize the infrastructure (like pod deletion assignation)
 const pipelineSteps = getPipelineStepNames();
 
-
-const notCreatedStatus = {
-  startDate: null,
-  stopDate: null,
-  status: pipelineConstants.NOT_CREATED,
-  error: false,
-  completedSteps: [],
+// buildResponse function is wrapper function to ensure that all pipeline-status
+// responses contain the same information and parameters
+// more specific building response should rely on calling this one
+const buildResponse = (processName, execution, paramsHash, error, completedSteps) => {
+  const response = {
+    [processName]: {
+      startDate: execution.startDate,
+      stopDate: execution.stopDate,
+      status: execution.status,
+      error,
+      completedSteps,
+      paramsHash,
+    },
+  };
+  return response;
 };
 
-// const date = (new Date()).toISOString();
-const buildCompletedStatus = (date) => ({
-  qc: {
-    startDate: date,
-    stopDate: date,
-    status: 'SUCCEEDED',
-    completedSteps: [
-      'ClassifierFilter',
-      'CellSizeDistributionFilter',
-      'MitochondrialContentFilter',
-      'NumGenesVsNumUmisFilter',
-      'DoubletScoresFilter',
-      'DataIntegration',
-      'ConfigureEmbedding'],
-  },
-  gem2s: {
-    startDate: date,
-    stopDate: date,
-    status: 'SUCCEEDED',
-    completedSteps: [
-      'DownloadGem',
-      'PreProcessing',
-      'EmptyDrops',
-      'DoubletScores',
-      'CreateSeurat',
-      'PrepareExperiment',
-      'UploadToAWS'],
-  },
-});
+const buildNotCreatedStatus = (processName) => {
+  const execution = {
+    startDate: null,
+    stopDate: null,
+    status: pipelineConstants.NOT_CREATED,
+  };
+  const paramsHash = undefined;
+  const error = false;
+  const completedSteps = [];
+  return buildResponse(processName, execution, paramsHash, error, completedSteps);
+};
 
+const buildCompletedStatus = (processName, date, paramsHash) => {
+  const execution = {
+    startDate: date,
+    stopDate: date,
+    status: pipelineConstants.SUCCEEDED,
+  };
+  const error = false;
+  let completedSteps;
+
+  switch (processName) {
+    case pipelineConstants.GEM2S_PROCESS_NAME:
+      completedSteps = gem2sPipelineSteps;
+      break;
+    case pipelineConstants.QC_PROCESS_NAME:
+      completedSteps = qcPipelineSteps;
+      break;
+    default:
+      throw new Error(`Unknown processName ${processName}`);
+  }
+  return buildResponse(processName, execution, paramsHash, error, completedSteps);
+};
+
+
+const getExecutionHistory = async (stepFunctions, executionArn) => {
+  let events = [];
+  let nextToken;
+  do {
+    // eslint-disable-next-line no-await-in-loop
+    const history = await stepFunctions.getExecutionHistory({
+      executionArn,
+      includeExecutionData: false,
+      nextToken,
+    }).promise();
+
+    events = [...events, ...history.events];
+    nextToken = history.nextToken;
+  } while (nextToken);
+
+  return events;
+};
+
+const checkError = (events) => {
+  const error = _.findLast(events, (elem) => elem.type === 'ExecutionFailed');
+
+  if (error) {
+    return error.executionFailedEventDetails;
+  }
+
+  return false;
+};
 
 const getStepsFromExecutionHistory = (events) => {
   class Branch {
@@ -148,6 +207,7 @@ const getStepsFromExecutionHistory = (events) => {
   return shortestCompletedToReport || [];
 };
 
+
 /*
      * Return `completedSteps` of the state machine (SM) associated to the `experimentId`'s pipeline
      * The code assumes that
@@ -164,12 +224,12 @@ const getPipelineStatus = async (experimentId, processName) => {
   let execution = {};
   let completedSteps = [];
   let error = false;
+  // only used in gem2s, will just be undefined for qc
+  const { paramsHash } = pipelinesHandles[processName] || {};
 
   // if there aren't ARNs just return NOT_CREATED status
   if (executionArn === '') {
-    return {
-      [processName]: notCreatedStatus,
-    };
+    return buildNotCreatedStatus(processName);
   }
 
   const stepFunctions = new AWS.StepFunctions({
@@ -188,9 +248,7 @@ const getPipelineStatus = async (experimentId, processName) => {
     // the pipeline losing annotations. This will be addressed checking if the
     // processed files exist in S3 to avoid allowing users to move onwards when the pipeline was not
     // actually run.
-    if ((config.clusterEnv === 'development' && e.code === pipelineConstants.EXECUTION_DOES_NOT_EXIST)
-      || (config.clusterEnv === 'staging' && e.code === pipelineConstants.EXECUTION_DOES_NOT_EXIST)
-      || (config.clusterEnv === 'production' && e.code === pipelineConstants.EXECUTION_DOES_NOT_EXIST)
+    if ((e.code === pipelineConstants.EXECUTION_DOES_NOT_EXIST)
       || (config.clusterEnv === 'staging' && e.code === pipelineConstants.ACCESS_DENIED)) {
       logger.log(
         `Returning a mocked success ${processName} - pipeline status because ARN ${executionArn} `
@@ -202,54 +260,21 @@ const getPipelineStatus = async (experimentId, processName) => {
       // staging dev we don't care about this
       const ninetyDaysAgo = new Date(new Date().setDate(new Date().getDate() - 90));
 
-      return {
-        [processName]: buildCompletedStatus(ninetyDaysAgo)[processName],
-      };
+      return buildCompletedStatus(processName, ninetyDaysAgo, paramsHash);
     }
 
     throw e;
   }
 
-  /* eslint-disable no-await-in-loop */
-  let events = [];
-  let nextToken;
-  do {
-    const history = await stepFunctions.getExecutionHistory({
-      executionArn,
-      includeExecutionData: false,
-      nextToken,
-    }).promise();
-
-    events = [...events, ...history.events];
-    nextToken = history.nextToken;
-  } while (nextToken);
-
-  error = _.findLast(events, (elem) => elem.type === 'ExecutionFailed');
-
-  if (error) {
-    error = error.executionFailedEventDetails;
-  }
-
+  const events = getExecutionHistory(stepFunctions, executionArn);
+  error = checkError(events);
   completedSteps = getStepsFromExecutionHistory(events);
 
-  const response = {
-    [processName]: {
-      startDate: execution.startDate,
-      stopDate: execution.stopDate,
-      status: execution.status,
-      error,
-      completedSteps,
-    },
-  };
-
-  if (processName === pipelineConstants.GEM2S_PROCESS_NAME) {
-    const { paramsHash } = pipelinesHandles[pipelineConstants.GEM2S_PROCESS_NAME];
-    response[pipelineConstants.GEM2S_PROCESS_NAME].paramsHash = paramsHash;
-  }
-
-  return response;
+  return buildResponse(processName, execution, paramsHash, error, completedSteps);
 };
 
 module.exports = getPipelineStatus;
 
 module.exports.getStepsFromExecutionHistory = getStepsFromExecutionHistory;
+module.exports.buildCompletedStatus = buildCompletedStatus;
+module.exports.checkError = checkError;

--- a/src/api/general-services/pipeline-status.js
+++ b/src/api/general-services/pipeline-status.js
@@ -181,14 +181,6 @@ const getPipelineStatus = async (experimentId, processName) => {
       executionArn,
     }).promise();
   } catch (e) {
-    // state machines in staging are removed after some time, in this situation we return
-    // NOT_CREATED status so that the pipeline can be run again
-    if (config.clusterEnv === 'staging' && e.code === pipelineConstants.EXECUTION_DOES_NOT_EXIST) {
-      return {
-        [processName]: notCreatedStatus,
-      };
-    }
-
     // if we get the execution does not exist it means we are using a pulled experiment so
     // just return a mock sucess status
     // TODO: state machines in production are deleted after 90 days, return a successful execution
@@ -197,8 +189,9 @@ const getPipelineStatus = async (experimentId, processName) => {
     // processed files exist in S3 to avoid allowing users to move onwards when the pipeline was not
     // actually run.
     if ((config.clusterEnv === 'development' && e.code === pipelineConstants.EXECUTION_DOES_NOT_EXIST)
-    || (config.clusterEnv === 'staging' && e.code === pipelineConstants.ACCESS_DENIED)
-    || (config.clusterEnv === 'production' && e.code === pipelineConstants.EXECUTION_DOES_NOT_EXIST)) {
+      || (config.clusterEnv === 'staging' && e.code === pipelineConstants.EXECUTION_DOES_NOT_EXIST)
+      || (config.clusterEnv === 'production' && e.code === pipelineConstants.EXECUTION_DOES_NOT_EXIST)
+      || (config.clusterEnv === 'staging' && e.code === pipelineConstants.ACCESS_DENIED)) {
       logger.log(
         `Returning a mocked success ${processName} - pipeline status because ARN ${executionArn} `
         + `does not exist and we are running in ${config.clusterEnv} so it means it's either a `

--- a/src/api/route-services/gem2s.js
+++ b/src/api/route-services/gem2s.js
@@ -8,7 +8,7 @@ const { createGem2SPipeline } = require('../general-services/pipeline-manage');
 const saveProcessingConfigFromGem2s = require('../../utils/hooks/save-gem2s-processing-config');
 const runQCPipeline = require('../../utils/hooks/run-qc-pipeline');
 const validateRequest = require('../../utils/schema-validator');
-const PipelineHook = require('../../utils/hookRunner');
+const PipelineHook = require('../../utils/hooks/hookRunner');
 const getLogger = require('../../utils/getLogger');
 
 const ExperimentService = require('./experiment');

--- a/src/api/route-services/pipeline-response.js
+++ b/src/api/route-services/pipeline-response.js
@@ -8,7 +8,7 @@ const getPipelineStatus = require('../general-services/pipeline-status');
 
 const ExperimentService = require('./experiment');
 const PlotsTablesService = require('./plots-tables');
-const PipelineHook = require('../../utils/hookRunner');
+const PipelineHook = require('../../utils/hooks/hookRunner');
 
 const plotsTableService = new PlotsTablesService();
 const experimentService = new ExperimentService();

--- a/src/utils/hooks/hookRunner.js
+++ b/src/utils/hooks/hookRunner.js
@@ -1,4 +1,4 @@
-const getLogger = require('./getLogger');
+const getLogger = require('../getLogger');
 
 const logger = getLogger();
 

--- a/tests/api/general-services/pipeline-status.test.js
+++ b/tests/api/general-services/pipeline-status.test.js
@@ -346,11 +346,8 @@ describe('pipelineStatus', () => {
   it('handles a gem2s execution does not exist exception', async () => {
     const status = await pipelineStatus(EXECUTION_DOES_NOT_EXIST, GEM2S_PROCESS_NAME);
 
-    const ninetyDaysAgo = new Date(new Date().setDate(new Date().getDate() - 90));
     const expected = {
       [GEM2S_PROCESS_NAME]: {
-        startDate: ninetyDaysAgo,
-        stopDate: ninetyDaysAgo,
         status: 'SUCCEEDED',
         completedSteps: [
           'DownloadGem',
@@ -364,7 +361,9 @@ describe('pipelineStatus', () => {
         paramsHash,
       },
     };
-    expect(status).toStrictEqual(expected);
+    expect(status).toEqual(expect.not.objectContaining(expected));
+    expect(status[GEM2S_PROCESS_NAME].startDate).toBeDefined();
+    expect(status[GEM2S_PROCESS_NAME].stopDate).toBeDefined();
 
     expect(mockDynamoGetItem).not.toHaveBeenCalled();
   });

--- a/tests/api/general-services/pipeline-status.test.js
+++ b/tests/api/general-services/pipeline-status.test.js
@@ -3,10 +3,148 @@ const AWS = require('../../../src/utils/requireAWS');
 const constants = require('../../../src/api/general-services/pipeline-manage/constants');
 const { fullHistory, singleIterationHistory, noPodsToDeleteHistory } = require('./pipeline-status.test.data');
 const pipelineStatus = require('../../../src/api/general-services/pipeline-status');
+const pipelineConstants = require('../../../src/api/general-services/pipeline-manage/constants');
+
 
 const {
   GEM2S_PROCESS_NAME, QC_PROCESS_NAME, OLD_QC_NAME_TO_BE_REMOVED,
 } = constants;
+
+// these are constants used to indicate to a mocked component whether they should return a
+// successful response with data or just an empty one
+const SUCCEEDED_ID = 'succeded_id';
+const EMPTY_ID = 'empty_id';
+// experimentID used to trigger an execution does not exist
+const EXECUTION_DOES_NOT_EXIST = 'EXECUTION_DOES_NOT_EXIST';
+const RANDOM_EXCEPTION = 'RANDOM_EXCEPTION';
+const paramsHash = '44c4c6e190e54c4b2740d37a861bb6954921730c';// pragma: allowlist secret
+
+const mockNotRunResponse = {
+  Item: {
+    meta: {
+      M: {
+        [GEM2S_PROCESS_NAME]: {
+          M: {
+            stateMachineArn: {
+              S: EMPTY_ID,
+            },
+            executionArn: {
+              S: '',
+            },
+            paramsHash: {
+              S: '',
+            },
+          },
+        },
+        [OLD_QC_NAME_TO_BE_REMOVED]: {
+          M: {
+            stateMachineArn: {
+              S: EMPTY_ID,
+            },
+            executionArn: {
+              S: '',
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+const mockRunResponse = {
+  Item: {
+    meta: {
+      M: {
+        [GEM2S_PROCESS_NAME]: {
+          M: {
+            stateMachineArn: {
+              S: SUCCEEDED_ID,
+            },
+            executionArn: {
+              S: SUCCEEDED_ID,
+            },
+            paramsHash: {
+              S: paramsHash,
+            },
+          },
+        },
+        [OLD_QC_NAME_TO_BE_REMOVED]: {
+          M: {
+            stateMachineArn: {
+              S: SUCCEEDED_ID,
+            },
+            executionArn: {
+              S: SUCCEEDED_ID,
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+const mockExecutionNotExistResponse = {
+  Item: {
+    meta: {
+      M: {
+        [GEM2S_PROCESS_NAME]: {
+          M: {
+            stateMachineArn: {
+              S: '',
+            },
+            executionArn: {
+              S: EXECUTION_DOES_NOT_EXIST,
+            },
+            paramsHash: {
+              S: paramsHash,
+            },
+          },
+        },
+        [OLD_QC_NAME_TO_BE_REMOVED]: {
+          M: {
+            stateMachineArn: {
+              S: '',
+            },
+            executionArn: {
+              S: EXECUTION_DOES_NOT_EXIST,
+            },
+          },
+        },
+      },
+    },
+  },
+};
+const mockRandomExceptionResponse = {
+  Item: {
+    meta: {
+      M: {
+        [GEM2S_PROCESS_NAME]: {
+          M: {
+            stateMachineArn: {
+              S: '',
+            },
+            executionArn: {
+              S: RANDOM_EXCEPTION,
+            },
+            paramsHash: {
+              S: paramsHash,
+            },
+          },
+        },
+        [OLD_QC_NAME_TO_BE_REMOVED]: {
+          M: {
+            stateMachineArn: {
+              S: '',
+            },
+            executionArn: {
+              S: RANDOM_EXCEPTION,
+            },
+          },
+        },
+      },
+    },
+  },
+};
 
 describe('getStepsFromExecutionHistory', () => {
   const truncateHistory = (lastEventId) => {
@@ -48,42 +186,85 @@ describe('getStepsFromExecutionHistory', () => {
   });
 });
 
-describe('pipelineStatus', () => {
-  const mockNotRunResponse = {
-    Item: {
-      meta: {
-        M: {
-          [GEM2S_PROCESS_NAME]: {
-            M: {
-              stateMachineArn: {
-                S: '',
-              },
-              executionArn: {
-                S: '',
-              },
-            },
-          },
-          [OLD_QC_NAME_TO_BE_REMOVED]: {
-            M: {
-              stateMachineArn: {
-                S: '',
-              },
-              executionArn: {
-                S: '',
-              },
-            },
-          },
-        },
+describe('checkError', () => {
+  const events = [
+    {
+      timestamp: {
+      },
+      type: 'TaskStateEntered',
+      id: 2,
+      previousEventId: 0,
+      stateEnteredEventDetails: {
+        name: 'DeleteCompletedPipelineWorker',
+        input: null,
       },
     },
+    {
+      timestamp: {
+      },
+      type: 'TaskScheduled',
+      id: 3,
+      previousEventId: 2,
+      taskScheduledEventDetails: {
+        resourceType: 'lambda',
+        resource: 'invoke',
+        region: 'eu-west-1',
+        parameters: '{"FunctionName":"arn:aws:lambda:eu-west-1:000000000000:function:remove-previous-pipeline-containers"}',
+        timeoutInSeconds: null,
+        heartbeatInSeconds: null,
+      },
+    },
+  ];
+  const failedEvents = [
+    {
+      timestamp: '2021-10-13T14:36:14.228000+02:00',
+      type: 'ExecutionFailed',
+      id: 130,
+      previousEventId: 129,
+      executionFailedEventDetails: {
+        error: 'NoPodsAvailable',
+        cause: 'No available and running pipeline pods.',
+      },
+    },
+  ];
 
-  };
+  it('returns an error for a failed execution', () => {
+    const error = pipelineStatus.checkError(failedEvents);
 
-  const mockDescribeExecution = jest.fn();
+    expect(error).toEqual({ cause: 'No available and running pipeline pods.', error: 'NoPodsAvailable' });
+  });
+
+  it('returns no error for correct execution', () => {
+    const error = pipelineStatus.checkError(events);
+
+    expect(error).toEqual(false);
+  });
+});
+
+
+describe('pipelineStatus', () => {
+  AWSMock.mock('DynamoDB', 'getItem', (params, callback) => {
+    const experimentId = params.Key.experimentId.S;
+    switch (experimentId) {
+      case EMPTY_ID:
+        callback(null, mockNotRunResponse);
+        break;
+      case SUCCEEDED_ID:
+        callback(null, mockRunResponse);
+        break;
+      case EXECUTION_DOES_NOT_EXIST:
+        callback(null, mockExecutionNotExistResponse);
+        break;
+      case RANDOM_EXCEPTION:
+        callback(null, mockRandomExceptionResponse);
+        break;
+      default:
+        throw new Error(`Unrecognized experiment ID ${experimentId}.`);
+    }
+  });
 
   const mockDynamoGetItem = jest.fn().mockImplementation(() => ({
     Item: AWS.DynamoDB.Converter.marshall({
-      // Dumb meaningless payload to prevent crahes
       meta: {},
       samples: {
         ids: [],
@@ -91,33 +272,160 @@ describe('pipelineStatus', () => {
     }),
   }));
 
-  beforeEach(() => {
-    AWSMock.setSDKInstance(AWS);
+  AWSMock.setSDKInstance(AWS);
 
-    AWSMock.mock('StepFunctions', 'describeExecution', (params, callback) => {
-      callback(null, mockDescribeExecution(params));
-    });
+  AWSMock.mock('StepFunctions', 'describeExecution', (params, callback) => {
+    const successfulExecution = {
+      stateMachineArn: 'arn:aws:states:eu-west-1:242905224710:execution:biomage-gem2s-development-11111444448882220044as80023023942342311',
+      startDate: new Date(0),
+      stopDate: new Date(0),
+      status: constants.SUCCEEDED,
+      error: true,
+      paramsHash,
+    };
+    const emptyExecution = {};
+    const errDoesNotExist = new Error(pipelineConstants.EXECUTION_DOES_NOT_EXIST);
+    errDoesNotExist.code = pipelineConstants.EXECUTION_DOES_NOT_EXIST;
 
-    AWSMock.mock('StepFunctions', 'getExecutionHistory', (params, callback) => {
-      callback(null, { events: [] });
-    });
+    const { executionArn } = params;
+    switch (executionArn) {
+      case SUCCEEDED_ID:
+        callback(null, successfulExecution);
+        break;
+      case EMPTY_ID:
+        callback(null, emptyExecution);
+        break;
+      case EXECUTION_DOES_NOT_EXIST:
+        throw errDoesNotExist;
+      default:
+        throw new Error(`Unexpected executionArn ${executionArn}`);
+    }
 
-    const getPipelineHandleSpy = jest.fn((x) => x);
-    AWSMock.mock('DynamoDB', 'getItem', (params, callback) => {
-      getPipelineHandleSpy(params);
-      callback(null, mockNotRunResponse);
-    });
+    callback(null, params);
   });
 
-  it('handles properly an empty dynamodb record', async () => {
-    const status = await pipelineStatus('1234', QC_PROCESS_NAME);
+  AWSMock.mock('StepFunctions', 'getExecutionHistory', (params, callback) => {
+    callback(null, { events: [] });
+  });
 
+  it('handles properly a gem2s empty dynamodb record', async () => {
+    const status = await pipelineStatus(EMPTY_ID, GEM2S_PROCESS_NAME);
+
+    expect(status).toStrictEqual({
+      [GEM2S_PROCESS_NAME]: {
+        startDate: null,
+        stopDate: null,
+        error: false,
+        status: constants.NOT_CREATED,
+        completedSteps: [],
+        paramsHash: undefined,
+      },
+    });
+
+    expect(mockDynamoGetItem).not.toHaveBeenCalled();
+  });
+
+  it('handles properly a qc empty dynamodb record', async () => {
+    const status = await pipelineStatus(EMPTY_ID, QC_PROCESS_NAME);
+
+    // we don't check with StrictEqual because response will contain
+    // undefined paramsHash and that is OK (only needed in gem2s)
     expect(status).toEqual({
       [QC_PROCESS_NAME]: {
         startDate: null,
         stopDate: null,
         error: false,
         status: constants.NOT_CREATED,
+        completedSteps: [],
+      },
+    });
+
+    expect(mockDynamoGetItem).not.toHaveBeenCalled();
+  });
+
+  it('handles a gem2s execution does not exist exception', async () => {
+    const status = await pipelineStatus(EXECUTION_DOES_NOT_EXIST, GEM2S_PROCESS_NAME);
+
+    const ninetyDaysAgo = new Date(new Date().setDate(new Date().getDate() - 90));
+    const expected = {
+      [GEM2S_PROCESS_NAME]: {
+        startDate: ninetyDaysAgo,
+        stopDate: ninetyDaysAgo,
+        status: 'SUCCEEDED',
+        completedSteps: [
+          'DownloadGem',
+          'PreProcessing',
+          'EmptyDrops',
+          'DoubletScores',
+          'CreateSeurat',
+          'PrepareExperiment',
+          'UploadToAWS'],
+        error: false,
+        paramsHash,
+      },
+    };
+    expect(status).toStrictEqual(expected);
+
+    expect(mockDynamoGetItem).not.toHaveBeenCalled();
+  });
+
+  it('handles a qc execution does not exist exception', async () => {
+    const status = await pipelineStatus(EXECUTION_DOES_NOT_EXIST, QC_PROCESS_NAME);
+
+    const ninetyDaysAgo = new Date(new Date().setDate(new Date().getDate() - 90));
+    const expected = {
+      [QC_PROCESS_NAME]: {
+        startDate: ninetyDaysAgo,
+        stopDate: ninetyDaysAgo,
+        status: 'SUCCEEDED',
+        completedSteps: [
+          'ClassifierFilter',
+          'CellSizeDistributionFilter',
+          'MitochondrialContentFilter',
+          'NumGenesVsNumUmisFilter',
+          'DoubletScoresFilter',
+          'DataIntegration',
+          'ConfigureEmbedding'],
+        error: false,
+      },
+    };
+    expect(status).toEqual(expected);
+
+    expect(mockDynamoGetItem).not.toHaveBeenCalled();
+  });
+
+  it('fails on random exception', async () => {
+    await expect(pipelineStatus(RANDOM_EXCEPTION, QC_PROCESS_NAME)).rejects.toThrow();
+  });
+
+  it('handles properly a gem2s dynamodb record', async () => {
+    const status = await pipelineStatus(SUCCEEDED_ID, GEM2S_PROCESS_NAME);
+
+    expect(status).toStrictEqual({
+      [GEM2S_PROCESS_NAME]: {
+        startDate: new Date(0),
+        stopDate: new Date(0),
+        status: constants.SUCCEEDED,
+        paramsHash,
+        error: false,
+        completedSteps: [],
+      },
+    });
+
+    expect(mockDynamoGetItem).not.toHaveBeenCalled();
+  });
+
+  it('handles properly a qc dynamodb record', async () => {
+    const status = await pipelineStatus(SUCCEEDED_ID, QC_PROCESS_NAME);
+
+    // we don't check with StrictEqual because response will contain
+    // undefined paramsHash and that is OK (only needed in gem2s)
+    expect(status).toEqual({
+      [QC_PROCESS_NAME]: {
+        startDate: new Date(0),
+        stopDate: new Date(0),
+        status: constants.SUCCEEDED,
+        error: false,
         completedSteps: [],
       },
     });

--- a/tests/test-utils/constants.js
+++ b/tests/test-utils/constants.js
@@ -53,6 +53,7 @@ const S3_WORKER_RESULT = {
   },
 };
 
+
 // Try to use realistic values but DO NOT USE real ones.
 module.exports = Object.freeze({
   SOCKET_ENDPOINT: 'localhost:5000',

--- a/tests/utils/hookRunner.test.js
+++ b/tests/utils/hookRunner.test.js
@@ -1,4 +1,4 @@
-const HookRunner = require('../../src/utils/hookRunner');
+const HookRunner = require('../../src/utils/hooks/hookRunner');
 
 describe('HookRunner', () => {
   it('initialize with an empty hooks list', () => {


### PR DESCRIPTION
Ticket: https://biomage.atlassian.net/browse/BIOMAGE-1517
Staging: https://ui-flaky-silver-gibbon.scp-staging.biomage.net/data-management

Main reason

aws deletes state machines after 90 days so backend-status calls fail. This PR is a temporary fix to avoid the "It's not you it's us" error. As discussed with Vicky, we will assume the user already run their experiment to avoid forcing them to rerun and lose their settings. The next fix will check whether those files exist in S3 to avoid redirecting users who actually haven't run the pipeline.

Changes
* Moved hookRunner to /hooks folder
* Added many tests to pipeline-status
* Refactored pipeline-status response handling to avoid forgetting to add params in some code paths 