### PR TITLE
Add different replica counts depending on environment

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -182,6 +182,7 @@ jobs:
             KUBERNETES_ENV="production"
             IMAGE_TAG="${REF_DASHED/refs-tags-/}"
             IMAGE_GLOB="semver:>=0.0.0"
+            REPLICA_COUNT="4"
           fi
 
           if [ "${{ matrix.environment }}" = "develop" ]; then
@@ -190,6 +191,7 @@ jobs:
             KUBERNETES_ENV="staging"
             IMAGE_TAG="$REF_DASHED-$GITHUB_SHA"
             IMAGE_GLOB="glob:$REF_DASHED-*"
+            REPLICA_COUNT="4"
           fi
 
           if [ "${{ matrix.environment }}" = "staging" ]; then
@@ -198,6 +200,7 @@ jobs:
             KUBERNETES_ENV="staging"
             IMAGE_TAG="$REF_DASHED-$GITHUB_SHA"
             IMAGE_GLOB="glob:$REF_DASHED-*"
+            REPLICA_COUNT="4"
           fi
 
           echo "::set-output name=kubernetes-env::$KUBERNETES_ENV"
@@ -216,6 +219,7 @@ jobs:
           | yq w -d1 - spec.values.image.registry "${{ steps.login-ecr.outputs.registry }}" \
           | yq w -d1 - spec.values.image.repository "$DEPLOYMENT_NAME" \
           | yq w -d1 - spec.values.image.tag "$IMAGE_TAG" \
+          | yq w -d1 - spec.values.replicaCount $REPLICA_COUNT \
           | yq w -d1 - spec.values.serviceAccount.iamRole "arn:aws:iam::${{ steps.setup-aws.outputs.aws-account-id }}:role/api-role-$KUBERNETES_ENV" \
           > $DEPLOYMENT_NAME.yaml
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -200,7 +200,7 @@ jobs:
             KUBERNETES_ENV="staging"
             IMAGE_TAG="$REF_DASHED-$GITHUB_SHA"
             IMAGE_GLOB="glob:$REF_DASHED-*"
-            REPLICA_COUNT="4"
+            REPLICA_COUNT="1"
           fi
 
           echo "::set-output name=kubernetes-env::$KUBERNETES_ENV"


### PR DESCRIPTION
This fixes an issue where on `staging` we run out of Pods because the number of replicas created for developer staging environments is too high.