### PR TITLE
[BIOMAGE-1550] using custom iac to test ee deployment

### DIFF
--- a/.flux.yaml
+++ b/.flux.yaml
@@ -20,7 +20,7 @@ spec:
   chart:
     git: git@github.com:biomage-ltd/iac
     path: charts/nodejs
-    ref: cluster-ee # TODO change before merging
+    ref: FILLED_IN_BY_CI
   values:
     service:
       externalPort: 3000

--- a/.flux.yaml
+++ b/.flux.yaml
@@ -18,9 +18,9 @@ metadata:
 spec:
   releaseName: FILLED_IN_BY_CI
   chart:
-    git: git@github.com:kafkasl/iac
+    git: git@github.com:biomage-ltd/iac
     path: charts/nodejs
-    ref: FILLED_IN_BY_CI
+    ref: cluster-ee # TODO change before merging
   values:
     service:
       externalPort: 3000

--- a/.flux.yaml
+++ b/.flux.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   releaseName: FILLED_IN_BY_CI
   chart:
-    git: git@github.com:biomage-ltd/iac
+    git: git@github.com:kafkasl/iac
     path: charts/nodejs
     ref: FILLED_IN_BY_CI
   values:
@@ -37,7 +37,7 @@ spec:
       minReplicas: 1
       maxReplicas: 1
       targetCPUUtilizationPercentage: 80
-    
+
     ingress:
       annotations:
         alb.ingress.kubernetes.io/healthcheck-path: /v1/health

--- a/src/api/routes/kubernetes.js
+++ b/src/api/routes/kubernetes.js
@@ -1,7 +1,6 @@
 const AWSXRay = require('aws-xray-sdk');
 const k8s = require('@kubernetes/client-node');
 const getLogger = require('../../utils/getLogger');
-const config = require('../../config');
 
 const kc = new k8s.KubeConfig();
 kc.loadFromDefault();
@@ -17,7 +16,7 @@ module.exports = {
     logger.log(`[${reason}] received kubernetes event: ${message} ${name} in ${namespace}`);
 
     // remove only pods in your namespace and due to backoff errors
-    if (namespace === `pipeline-${config.sandboxId}` && reason === 'BackOff' && config.clusterEnv !== 'development') {
+    if ((namespace.match('^pipeline-.*') || namespace.match('^worker-.*')) && reason === 'BackOff') {
       try {
         const k8sApi = kc.makeApiClient(k8s.CoreV1Api);
         logger.log(`removing pod ${name} in ${namespace}`);

--- a/tests/utils/hooks/pod-cleanup.test.js
+++ b/tests/utils/hooks/pod-cleanup.test.js
@@ -1,0 +1,58 @@
+
+const k8s = require('@kubernetes/client-node');
+const fake = require('../../test-utils/constants');
+
+jest.mock('@kubernetes/client-node');
+
+const mockPodsList = {
+  body: {
+    items: [
+      {
+        metadata: {
+          name: 'pipeline-X1',
+          generateName: 'pipeline-fasdfasdf-',
+          namespace: 'pipeline-X',
+        },
+      },
+      {
+        metadata: {
+          name: 'pipeline-X2',
+          generateName: 'pipeline-2342fasd-',
+          namespace: 'pipeline-X',
+        },
+      },
+    ],
+  },
+};
+
+
+const deleteNamespacedPod = jest.fn();
+const patchNamespacedPod = jest.fn();
+const listNamespacedPod = jest.fn(() => mockPodsList);
+const mockApi = {
+  deleteNamespacedPod,
+  patchNamespacedPod,
+  listNamespacedPod,
+};
+
+k8s.KubeConfig.mockImplementation(() => {
+  console.debug('mocking the constructor');
+  return {
+    loadFromDefault: jest.fn(),
+    makeApiClient: (() => mockApi),
+  };
+});
+
+const { cleanupPods } = require('../../../src/utils/hooks/pod-cleanup');
+
+
+describe('cleanupPods', () => {
+  it('calls delete pod for each element in the message', async () => {
+    const message = {
+      experimentId: fake.EXPERIMENT_ID,
+    };
+    await cleanupPods(message);
+    expect(listNamespacedPod).toHaveBeenCalledTimes(1);
+    expect(deleteNamespacedPod).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
# Background
#### Link to issue 

https://biomage.atlassian.net/browse/BIOMAGE-1550

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

https://github.com/biomage-ltd/pipeline/pull/186
https://github.com/biomage-ltd/worker/pull/212
https://github.com/biomage-ltd/iac/pull/202

#### Anything else the reviewers should know about the changes here

Removed worker & pipeline cleanup operators because it will because crashed pods will be handled by the API.

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging
- [ ] Passed integration tests 

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
