### PR TITLE
Disable Horizontal Pod Autoscaler for API

### DIFF
--- a/.flux.yaml
+++ b/.flux.yaml
@@ -33,11 +33,7 @@ spec:
       requests:
         cpu: "100m"
     hpa:
-      enabled: true
-      minReplicas: 1
-      maxReplicas: 1
-      targetCPUUtilizationPercentage: 80
-    
+      enabled: false
     ingress:
       annotations:
         alb.ingress.kubernetes.io/healthcheck-path: /v1/health


### PR DESCRIPTION
This disables a HPA that was enabled for the API that automatically scales pods back to one if no usage is detected.