### PR TITLE
Fix metadata not being sent with correct order for sorted samples

### DIFF
--- a/src/api/route-services/gem2s.js
+++ b/src/api/route-services/gem2s.js
@@ -51,8 +51,6 @@ class Gem2sService {
 
     const defaultMetadataValue = 'N.A.';
 
-    const samplesEntries = Object.entries(samples);
-
     logger.log('Generating task params');
 
     const taskParams = {
@@ -72,9 +70,11 @@ class Gem2sService {
         // Make sure the key does not contain '-' as it will cause failure in GEM2S
         const sanitizedKey = key.replace(/-+/g, '_');
 
-        acc[sanitizedKey] = samplesEntries.map(
-          ([, sample]) => sample.metadata[key] || defaultMetadataValue,
-        );
+        acc[sanitizedKey] = experiment.sampleIds.map((sampleId) => {
+          const sample = samples[sampleId];
+          return sample.metadata[key] || defaultMetadataValue;
+        });
+
         return acc;
       }, {});
     }

--- a/tests/api/route-services/__snapshots__/gem2s.test.js.snap
+++ b/tests/api/route-services/__snapshots__/gem2s.test.js.snap
@@ -75,6 +75,12 @@ Object {
   "input": Object {
     "type": "10x",
   },
+  "metadata": Object {
+    "group": Array [
+      "case",
+      "control",
+    ],
+  },
   "organism": null,
   "projectId": "project-2",
   "sampleIds": Array [

--- a/tests/api/route-services/gem2s.test.js
+++ b/tests/api/route-services/gem2s.test.js
@@ -96,6 +96,17 @@ describe('gem2s', () => {
     expect(taskParams).toMatchSnapshot();
   });
 
+  it('generateGem2sParams - Should order metadata tracks according to sampleIds order', async () => {
+    mockGem2sParamsBackendCall();
+    const taskParams = await Gem2sService.generateGem2sParams(experimentId, mockAuthJwt);
+
+    mockGem2sParamsBackendCall({ sampleIds: taskParams.sampleIds.reverse() });
+    const taskParamsReversed = await Gem2sService.generateGem2sParams(experimentId, mockAuthJwt);
+
+    expect(taskParams.metadata).toEqual({ group: ['case', 'control'] });
+    expect(taskParamsReversed.metadata).toEqual({ group: ['control', 'case'] });
+  });
+
   it('sendUpdateToSubscribed - Should send update if payloads are correct', async () => {
     const mockedSocketsEmit = jest.fn();
     const mockIo = {

--- a/tests/api/route-services/gem2s.test.js
+++ b/tests/api/route-services/gem2s.test.js
@@ -30,13 +30,13 @@ const mockGem2sParamsBackendCall = (
   };
 
   const samplesResponse = {
-    'sample-1': { name: 'Sample 1' },
-    'sample-2': { name: 'Sample 2' },
+    'sample-1': { name: 'Sample 1', metadata: { group: 'case' } },
+    'sample-2': { name: 'Sample 2', metadata: { group: 'control' } },
     ...customSamplesResponse,
   };
 
   const metadataResponse = {
-    metadataKeys: [],
+    metadataKeys: ['group'],
     ...customMetadataResponse,
   };
 


### PR DESCRIPTION
# Background
#### Link to issue

https://biomage.atlassian.net/jira/software/c/projects/BIOMAGE/boards/1?modal=detail&selectedIssue=BIOMAGE-1587 

#### Link to staging deployment URL 
https://ui-martinfosco-api264.scp-staging.biomage.net/

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging
- [ ] Passed integration tests 

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-ltd/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-ltd/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-ltd/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
