### PR TITLE
allow additional properties on sample json

### DIFF
--- a/src/specs/models/samples-bodies/Sample.v1.yaml
+++ b/src/specs/models/samples-bodies/Sample.v1.yaml
@@ -45,5 +45,3 @@ required:
   - error
   - fileNames
   - files
-
-additionalProperties: false

--- a/tests/api/routes/samples.test.js
+++ b/tests/api/routes/samples.test.js
@@ -69,7 +69,7 @@ describe('tests for samples route', () => {
       });
   });
 
-  it('Updating with extra properties returns error 400', async (done) => {
+  it('Updating with extra properties does not return error', async (done) => {
     const correctSample = dataFactory.getSamplesEntry();
 
     const extraPropertiesBodySample = _.cloneDeep(correctSample);
@@ -78,7 +78,7 @@ describe('tests for samples route', () => {
 
     request(app)
       .put('/v1/projects/someId/experimentId/samples')
-      .expect(400)
+      .expect(200)
       .send(extraPropertiesBodySample)
       .end((err) => {
         if (err) {
@@ -122,7 +122,7 @@ describe('tests for samples route', () => {
       });
   });
 
-  it('Creating with extra properties returns error 400', async (done) => {
+  it('Creating with extra properties does not return error', async (done) => {
     const correctSample = dataFactory.getSamplesEntry();
 
     const extraPropertiesBodySample = _.cloneDeep(correctSample);
@@ -131,7 +131,7 @@ describe('tests for samples route', () => {
 
     request(app)
       .post('/v1/projects/someId/experimentId/samples')
-      .expect(400)
+      .expect(200)
       .send(extraPropertiesBodySample['sample-1'])
       .end((err) => {
         if (err) {


### PR DESCRIPTION
# Description
Allow additional property on `sample` object.

PR #305 deletes the requirements of `sample` object to have `species`, a property that we are not using anymore. However, this property still exists in old samples, and we have set the shape of this object to not allow the existence of additional properties. This causes errors. This PR allows for additional properties to allow for backward compatibility.

# Details
#### URL to issue
N/A

#### Link to staging deployment URL (or set N/A)
https://ui-agi-api307.scp-staging.biomage.net/

#### Links to any PRs or resources related to this PR
https://github.com/hms-dbmi-cellenics/api/pull/305

#### Integration test branch
master

# Merge checklist
Your changes will be ready for merging after all of the steps below have been completed.

### Code updates
Have best practices and ongoing refactors being observed in this PR
- [x] Migrated any selector / reducer used to the new format.

### Manual/unit testing
- [X] Tested changes using InfraMock locally **or** no tests required for change, e.g. Kubernetes chart updates.
- [X] Validated that current unit tests for code work as expected and are sufficient for code coverage **or** no unit tests required for change, e.g. documentation update.
- [X] Unit tests written **or** no unit tests required for change, e.g. documentation update.

### Integration testing
**You must check the box below** to run integration tests on the latest commit on your PR branch.
Integration tests have to pass before the PR can be merged. Without checking the box, your PR
**will not pass** the required status checks for merging.

- [x] Started end-to-end tests on the latest commit.

### Documentation updates
- [X] Relevant Github READMEs updated **or** no GitHub README updates required.
- [X] Relevant Wiki pages created/updated **or** no Wiki updates required.

### Optional
- [ ] Staging environment is unstaged before merging.
- [ ] Photo of a cute animal attached to this PR.