### PR TITLE
Revert bugged sample update implementation

### DIFF
--- a/tests/api/route-services/samples.test.js
+++ b/tests/api/route-services/samples.test.js
@@ -67,19 +67,37 @@ describe('tests for the samples service', () => {
     });
   });
 
-  it('updateSamples patches instead of replace', async () => {
+  it('updateSamples correctly updates samples ', async () => {
     const projectUuid = 'project-1';
     const experimentId = 'experiment-1';
 
     const dbData = {
       samples: {
-        'sample-1': { name: 'sample-1' },
+        'sample-1': {
+          name: 'sample-1',
+          metadata: {
+            track_1: 'value_1',
+            track_2: 'value_2',
+          },
+        },
       },
     };
 
     const newData = {
-      'sample-2': { name: 'sample-2' },
-      'sample-3': { name: 'sample-3' },
+      'sample-1': {
+        name: 'new-sample-1-name',
+        metadata: {
+          track_1: 'value_2',
+          track_2: 'value_3',
+        },
+      },
+      'sample-2': {
+        name: 'sample-2',
+        metadata: {
+          track_1: "value_1'",
+          track_2: 'value_2',
+        },
+      },
     };
 
     const marshalledKey = AWS.DynamoDB.Converter.marshall({
@@ -87,7 +105,7 @@ describe('tests for the samples service', () => {
     });
 
     const marshalledData = AWS.DynamoDB.Converter.marshall({
-      ':samples': { ...dbData.samples, ...newData },
+      ':samples': newData,
       ':projectUuid': projectUuid,
     });
 

--- a/tests/api/route-services/samples.test.js
+++ b/tests/api/route-services/samples.test.js
@@ -78,6 +78,7 @@ describe('tests for the samples service', () => {
           metadata: {
             track_1: 'value_1',
             track_2: 'value_2',
+            track_3: 'value_3',
           },
         },
       },

--- a/tests/api/route-services/samples.test.js
+++ b/tests/api/route-services/samples.test.js
@@ -188,11 +188,16 @@ describe('tests for the samples service', () => {
 
     expect(res).toEqual(OK());
 
+    // Update samples
     expect(updateItemSpy.mock.calls[0]).toMatchSnapshot();
+
+    // Update projects
     expect(updateItemSpy.mock.calls[1]).toMatchSnapshot();
+
+    // Update experiments
     expect(updateItemSpy.mock.calls[2]).toMatchSnapshot();
 
-    // Only these two calls to dynamo were made
+    // Only these three calls to dynamo were made
     expect(updateItemSpy.mock.calls).toHaveLength(3);
   });
 });


### PR DESCRIPTION
# Description
Changes to sample update introduced by #305 causes deletion of metadata tracks to still persis in DynamoDB.

This PR reverts those changes and introduces better test that take account of metadata track values and deletion.

# Details
#### URL to issue
N/A

#### Link to staging deployment URL (or set N/A)
https://ui-agi-api308.scp-staging.biomage.net/

#### Links to any PRs or resources related to this PR
#305 

#### Integration test branch
master

# Merge checklist
Your changes will be ready for merging after all of the steps below have been completed.

### Code updates
Have best practices and ongoing refactors being observed in this PR
- [X] Migrated any selector / reducer used to the new format.

### Manual/unit testing
- [X] Tested changes using InfraMock locally **or** no tests required for change, e.g. Kubernetes chart updates.
- [X] Validated that current unit tests for code work as expected and are sufficient for code coverage **or** no unit tests required for change, e.g. documentation update.
- [X] Unit tests written **or** no unit tests required for change, e.g. documentation update.

### Integration testing
**You must check the box below** to run integration tests on the latest commit on your PR branch.
Integration tests have to pass before the PR can be merged. Without checking the box, your PR
**will not pass** the required status checks for merging.

- [ ] Started end-to-end tests on the latest commit.

### Documentation updates
- [X] Relevant Github READMEs updated **or** no GitHub README updates required.
- [X] Relevant Wiki pages created/updated **or** no Wiki updates required.

### Optional
- [ ] Staging environment is unstaged before merging.
- [ ] Photo of a cute animal attached to this PR.