### PR TITLE
[BIOMAGE-1775] Restrictd more delete events fltering

### DIFF
--- a/src/api/routes/kubernetes.js
+++ b/src/api/routes/kubernetes.js
@@ -18,7 +18,7 @@ module.exports = {
 
       // remove only pods in your namespace and due to backoff errors
       if ((namespace.match('^pipeline-.*') || namespace.match('^worker-.*'))
-       && reason === 'BackOff' && type !== 'Normal' && message.contains('restarting')) {
+       && reason === 'BackOff' && type !== 'Normal' && message.includes('restarting')) {
         const k8sApi = kc.makeApiClient(k8s.CoreV1Api);
         logger.log(`removing pod ${name} in ${namespace}`);
         await k8sApi.deleteNamespacedPod(name, namespace);

--- a/src/api/routes/kubernetes.js
+++ b/src/api/routes/kubernetes.js
@@ -11,11 +11,14 @@ module.exports = {
   'kubernetes#event': async (req, res, next) => {
     logger.log('received kubernetes event');
     try {
-      const { reason, message, involvedObject: { name, namespace } } = req.body;
-      logger.log(`[${reason}] received kubernetes event: ${message} ${name} in ${namespace}`);
+      const {
+        reason, message, type, involvedObject: { name, namespace },
+      } = req.body;
+      logger.log(`[${reason}] received ${type} kubernetes event: ${message} ${name} in ${namespace}`);
 
       // remove only pods in your namespace and due to backoff errors
-      if ((namespace.match('^pipeline-.*') || namespace.match('^worker-.*')) && reason === 'BackOff') {
+      if ((namespace.match('^pipeline-.*') || namespace.match('^worker-.*'))
+       && reason === 'BackOff' && type !== 'Normal' && message.contains('restarting')) {
         const k8sApi = kc.makeApiClient(k8s.CoreV1Api);
         logger.log(`removing pod ${name} in ${namespace}`);
         await k8sApi.deleteNamespacedPod(name, namespace);


### PR DESCRIPTION
# Description
It happens that the kubernetes events reason `BackOff` is an umbrella term describing many different situations. We use it to check whether a pod is in a crash loop but checking only the `reason` matches other events like simply pulling a new image (and having to backoff due to throttling). This PR makes the filtering more exhaustive by checking that the type is not `Normal` (which happens for image pulling) and checking that the message contains the `restarting` word. 

# Details
#### URL to issue
https://biomage.atlassian.net/browse/BIOMAGE-1775

#### Link to staging deployment URL (or set N/A)
N/A

#### Links to any PRs or resources related to this PR
https://github.com/hms-dbmi-cellenics/iac/pull/264

#### Integration test branch
master
<!---
  The branch of the integration test this PR will be run against

  If you DID NOT modify the integration tests for this PR, this can be left as `master`.

  If you DID modify the integration tests for this PR, add the name of the branch you created
  in hms-dbmi-cellenics/testing that will be used to test this branch.
-->

# Merge checklist
Your changes will be ready for merging after all of the steps below have been completed.
<!---
  The required checks will not pass until all the boxes below have been checked.
-->

### Code updates
Have best practices and ongoing refactors being observed in this PR
- [x] Migrated any selector / reducer used to the new format.

### Manual/unit testing
- [x] Tested changes using InfraMock locally **or** no tests required for change, e.g. Kubernetes chart updates.
- [x] Validated that current unit tests for code work as expected and are sufficient for code coverage **or** no unit tests required for change, e.g. documentation update.
- [x] Unit tests written **or** no unit tests required for change, e.g. documentation update.

<!---
  Download the latest production data using `biomage experiment pull`.
  To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
  To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/biomage-utils
-->

### Integration testing
**You must check the box below** to run integration tests on the latest commit on your PR branch.
Integration tests have to pass before the PR can be merged. Without checking the box, your PR
**will not pass** the required status checks for merging.

- [x] Started end-to-end tests on the latest commit.

### Documentation updates
- [x] Relevant Github READMEs updated **or** no GitHub README updates required.
- [x] Relevant Wiki pages created/updated **or** no Wiki updates required.

### Optional
- [ ] Staging environment is unstaged before merging.
- [ ] Photo of a cute animal attached to this PR.