### PR TITLE
[BIOMAGE-1965] - Fix rerunning of embedding in old experiments

### DIFF
--- a/src/api.v2/helpers/pipeline/constants.js
+++ b/src/api.v2/helpers/pipeline/constants.js
@@ -23,6 +23,10 @@ const NOT_CREATED = 'NOT_CREATED';
 const EXECUTION_DOES_NOT_EXIST = 'ExecutionDoesNotExist';
 const ACCESS_DENIED = 'AccessDeniedException';
 
+// Custom date to return if execution history can no longer be found in StepFunctions
+// because AWS deletes execution history more than 90 days after the execution is completed
+const EXPIRED_EXECUTION_DATE = '2020-01-01T00:00:00.000Z';
+
 module.exports = {
   QC_PROCESS_NAME,
   GEM2S_PROCESS_NAME,
@@ -36,4 +40,5 @@ module.exports = {
   EXECUTION_DOES_NOT_EXIST,
   ACCESS_DENIED,
   ASSIGN_POD_TO_PIPELINE,
+  EXPIRED_EXECUTION_DATE,
 };

--- a/src/api.v2/helpers/pipeline/constants.js
+++ b/src/api.v2/helpers/pipeline/constants.js
@@ -25,7 +25,7 @@ const ACCESS_DENIED = 'AccessDeniedException';
 
 // Custom date to return if execution history can no longer be found in StepFunctions
 // because AWS deletes execution history more than 90 days after the execution is completed
-const EXPIRED_EXECUTION_DATE = '2020-01-01T00:00:00.000Z';
+const EXPIRED_EXECUTION_DATE = '2019-05-19T00:00:00.000Z';
 
 module.exports = {
   QC_PROCESS_NAME,

--- a/src/api.v2/helpers/pipeline/getPipelineStatus.js
+++ b/src/api.v2/helpers/pipeline/getPipelineStatus.js
@@ -4,6 +4,7 @@ const AWS = require('../../../utils/requireAWS');
 const ExperimentExecution = require('../../model/ExperimentExecution');
 
 const config = require('../../../config');
+const { EXPIRED_EXECUTION_DATE } = require('./constants');
 const getLogger = require('../../../utils/getLogger');
 const pipelineConstants = require('./constants');
 const { getPipelineStepNames } = require('./pipelineConstruct/skeletons');
@@ -263,11 +264,10 @@ const getPipelineStatus = async (experimentId, processName) => {
         + 'doesn\'t have its latest execution stored in sql.',
       );
 
-      // we set as date 90 days ago which is when the state machine expire in production, in
-      // staging dev we don't care about this
-      const ninetyDaysAgo = new Date(new Date().setDate(new Date().getDate() - 90));
+      // we set a custom date that can be used by the UI to reliably generate ETag
+      const fixedPipelineDate = EXPIRED_EXECUTION_DATE;
 
-      return buildCompletedStatus(processName, ninetyDaysAgo, paramsHash);
+      return buildCompletedStatus(processName, fixedPipelineDate, paramsHash);
     }
 
     throw e;

--- a/tests/api.v2/helpers/pipeline/getPipelineStatus.test.js
+++ b/tests/api.v2/helpers/pipeline/getPipelineStatus.test.js
@@ -11,7 +11,7 @@ const experimentExecutionInstance = ExperimentExecution();
 
 jest.mock('../../../../src/api.v2/model/ExperimentExecution');
 
-jest.useFakeTimers('modern').setSystemTime(new Date('2020-01-01').getTime());
+jest.useFakeTimers('modern').setSystemTime(new Date(pipelineConstants.EXPIRED_EXECUTION_DATE).getTime());
 
 const {
   GEM2S_PROCESS_NAME, QC_PROCESS_NAME,
@@ -348,12 +348,10 @@ describe('pipelineStatus', () => {
         EXECUTION_DOES_NOT_EXIST_NULL_SQL_ID, GEM2S_PROCESS_NAME,
       );
 
-      const ninetyDaysAgo = new Date(new Date().setDate(new Date().getDate() - 90));
-
       const expected = {
         [GEM2S_PROCESS_NAME]: {
-          startDate: ninetyDaysAgo,
-          stopDate: ninetyDaysAgo,
+          startDate: pipelineConstants.EXPIRED_EXECUTION_DATE,
+          stopDate: pipelineConstants.EXPIRED_EXECUTION_DATE,
           status: 'SUCCEEDED',
           completedSteps: [
             'DownloadGem',


### PR DESCRIPTION
# Description
### Problem
Embedding resets on some experiments when the page is refreshed.

### Cause
This happens because the UI fails to generate the correct ETag to get previously calculated embedding. A parameter of the calculation is the time the QC pipeline was last run. This is usually retrieved from the pipeline execution history from AWS. Unfortunately, AWS only keeps 90 days of execution history. To remedy this, the API dynamically generates a date. This results in the pipeline last run date to be different everytime the page is refreshed for experiments whose execution history is erased, i.e. pipelines that are executed more than 90 days ago.

### Solution
API V2 actually stores the last execution history of the pipeline in the database and will return this if the pipeline is not found. However, there are experiments which has been run more than 90 days before v2 was released. For these exepriments, we return a fixed value of the date.

Aside from this, some randomness also arise from the UMAP function provided by Seurat. Alex's [PR to update the Seurat version](https://github.com/hms-dbmi-cellenics/worker/pull/274) fixes this issue. Sara has written some note on that in the ticket.

More details fleshed out the ticket: https://biomage.atlassian.net/browse/BIOMAGE-1965

Staging link: https://ui-agi-beady-gibbon.scp-staging.biomage.net/
# Details
#### URL to issue
https://biomage.atlassian.net/browse/BIOMAGE-1965

#### Link to staging deployment URL (or set N/A)
N/A

#### Links to any PRs or resources related to this PR
N/A

#### Integration test branch
master

# Merge checklist
Your changes will be ready for merging after all of the steps below have been completed.

### Code updates
Have best practices and ongoing refactors being observed in this PR
- [ ] Migrated any selector / reducer used to the new format.

### Manual/unit testing
- [ ] Tested changes using InfraMock locally **or** no tests required for change, e.g. Kubernetes chart updates.
- [ ] Validated that current unit tests for code work as expected and are sufficient for code coverage **or** no unit tests required for change, e.g. documentation update.
- [ ] Unit tests written **or** no unit tests required for change, e.g. documentation update.

### Integration testing
**You must check the box below** to run integration tests on the latest commit on your PR branch.
Integration tests have to pass before the PR can be merged. Without checking the box, your PR
**will not pass** the required status checks for merging.

- [x] Started end-to-end tests on the latest commit.

### Documentation updates
- [ ] Relevant Github READMEs updated **or** no GitHub README updates required.
- [ ] Relevant Wiki pages created/updated **or** no Wiki updates required.

### Optional
- [ ] Staging environment is unstaged before merging.
- [ ] Photo of a cute animal attached to this PR.