### PR TITLE
Fix naming of PR_GITHUB_REF 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -187,7 +187,7 @@ jobs:
             # Construct the REF_ID for our pull request in the same format
             # We can't use GITHUB_REF because it is set to master
             # More info: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
-            PR_GITHUB_REF="refs/pull/${{ github.event.pull_request.number }}/head"
+            PR_GITHUB_REF="refs/pull/${{ github.event.pull_request.number }}/merge"
             PR_REF_ID=$(echo $PR_GITHUB_REF | sed 's/\//-/g')
 
             IMAGE_TAG="$PR_REF_ID-$COMMIT_SHA-$TIMESTAMP"


### PR DESCRIPTION
# Description
<!---  Write a brief description of what your code does and how it relates to the issue it is resolving or feature enhancement it is implementing. -->

# Details
#### URL to issue
<!---
  Delete this comment and include the URL of the issue the pull request is related to.
  If no issue exists for this PR, replace this comment with N/A.

  Your pull request will not pass the required checks if this is not followed.
-->

#### Link to staging deployment URL (or set N/A)
<!---
  Delete this comment and include the URL of the staging environment for this pull request.
  Refer to https://github.com/hms-dbmi-cellenics/cellenics-utils#stage on how to stage a staging environment.
  If a staging environment for testing is not necessary for this PR, replace this comment with N/A 
  and explain why a staging environment is not required for this PR.

  Your pull request will not pass the required checks if this is not followed.
-->

#### Links to any PRs or resources related to this PR
<!---
  Delete this comment and include the URLs of any pull requests that are related to this PR.
  Place each PR on a new line.
-->

#### Integration test branch
master
<!---
  The branch of the integration test this PR will be run against

  If you DID NOT modify the integration tests for this PR, this can be left as `master`.

  If you DID modify the integration tests for this PR, add the name of the branch you created
  in hms-dbmi-cellenics/testing that will be used to test this branch.
-->

# Merge checklist
Your changes will be ready for merging after all of the steps below have been completed.
<!---
  The required checks will not pass until all the boxes below have been checked.
-->

### Code updates
Have best practices and ongoing refactors being observed in this PR
- [ ] Migrated any selector / reducer used to the new format.
- [ ] All new dependency licenses have been checked for compatibility

### Manual/unit testing
- [ ] Tested changes using InfraMock locally **or** no tests required for change, e.g. Kubernetes chart updates.
- [ ] Validated that current unit tests for code work as expected and are sufficient for code coverage **or** no unit tests required for change, e.g. documentation update.
- [ ] Unit tests written **or** no unit tests required for change, e.g. documentation update.

<!---
  Download the latest production data using `cellenics experiment pull`.
  To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
  To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/cellenics-utils
-->

### Integration testing
**You must check the box below** to run integration tests on the latest commit on your PR branch.
Integration tests have to pass before the PR can be merged. Without checking the box, your PR
**will not pass** the required status checks for merging.

- [ ] Started end-to-end tests on the latest commit.

### Documentation updates
- [ ] Relevant Github READMEs updated **or** no GitHub README updates required.
- [ ] Relevant Wiki pages created/updated **or** no Wiki updates required.

### Optional
- [ ] Staging environment is unstaged before merging.
- [ ] Photo of a cute animal attached to this PR.
