### PR TITLE
Avoid replacing PR with empty body

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,6 +67,7 @@ jobs:
           echo "EOF" >> "$GITHUB_OUTPUT"
 
       - id: uncheck-integration-checkbox
+        if: steps.create-unchecked-pr-body.outputs.body != ''
         name: Uncheck the integration checkbox
         uses: tzkhan/pr-update-action@v2
         with:


### PR DESCRIPTION
# Description
The action we use to retrieve the PR body `jwalton/gh-find-current-pr` does not seem to work with `pull_request_target` as opposed to `pull_request` so the body it retuns is empty and thus deletes the whole PR text instead of unchecking the integration test. We are not using the integration test check so far, so I just added an if checking whether the returned PR body is empty (in case we want to reuse that piece of code).

https://github.com/orgs/hms-dbmi-cellenics/projects/4?pane=issue&itemId=36760352

# Details
#### URL to issue
N/A

#### Link to staging deployment URL (or set N/A)
N/A

#### Links to any PRs or resources related to this PR
<!---
  Delete this comment and include the URLs of any pull requests that are related to this PR.
  Place each PR on a new line.
-->

#### Integration test branch
master
<!---
  The branch of the integration test this PR will be run against

  If you DID NOT modify the integration tests for this PR, this can be left as `master`.

  If you DID modify the integration tests for this PR, add the name of the branch you created
  in hms-dbmi-cellenics/testing that will be used to test this branch.
-->

# Merge checklist
Your changes will be ready for merging after all of the steps below have been completed.
<!---
  The required checks will not pass until all the boxes below have been checked.
-->

### Code updates
Have best practices and ongoing refactors being observed in this PR
- [ ] Migrated any selector / reducer used to the new format.
- [ ] All new dependency licenses have been checked for compatibility

### Manual/unit testing
- [ ] Tested changes using InfraMock locally **or** no tests required for change, e.g. Kubernetes chart updates.
- [ ] Validated that current unit tests for code work as expected and are sufficient for code coverage **or** no unit tests required for change, e.g. documentation update.
- [ ] Unit tests written **or** no unit tests required for change, e.g. documentation update.

<!---
  Download the latest production data using `cellenics experiment pull`.
  To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
  To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/cellenics-utils
-->

### Integration testing
**You must check the box below** to run integration tests on the latest commit on your PR branch.
Integration tests have to pass before the PR can be merged. Without checking the box, your PR
**will not pass** the required status checks for merging.

- [x] Started end-to-end tests on the latest commit.

### Documentation updates
- [ ] Relevant Github READMEs updated **or** no GitHub README updates required.
- [ ] Relevant Wiki pages created/updated **or** no Wiki updates required.

### Optional
- [ ] Staging environment is unstaged before merging.
- [ ] Photo of a cute animal attached to this PR.
