### PR TITLE
Fix upload of noncompressed files

### DIFF
--- a/src/api.v2/controllers/sampleFileController.js
+++ b/src/api.v2/controllers/sampleFileController.js
@@ -51,7 +51,7 @@ const beginUpload = async (req, res) => {
   if (!['uploading', 'compressing'].includes(uploadStatus)) {
     throw new MethodNotAllowedError(
       `Sample file ${sampleFileId} is not in the process of being uploaded. 
-      No sample files can be replaced in s3, to replace a file referenced in a sample, create a new file for it`,
+      No sample files can be replaced in s3, to replace a file referenced by a sample, create a new file for it`,
     );
   }
 

--- a/src/api.v2/routes/sampleFile.js
+++ b/src/api.v2/routes/sampleFile.js
@@ -1,5 +1,5 @@
 const {
-  createFile, patchFile, getS3DownloadUrl,
+  createFile, patchFile, getS3DownloadUrl, beginUpload,
 } = require('../controllers/sampleFileController');
 
 const { expressAuthorizationMiddleware } = require('../middlewares/authMiddlewares');
@@ -12,6 +12,10 @@ module.exports = {
   'sampleFile#patch': [
     expressAuthorizationMiddleware,
     (req, res, next) => patchFile(req, res).catch(next),
+  ],
+  'sampleFile#beginUpload': [
+    expressAuthorizationMiddleware,
+    (req, res, next) => beginUpload(req, res).catch(next),
   ],
   'sampleFile#downloadUrl': [
     expressAuthorizationMiddleware,

--- a/src/specs/api.v2.yaml
+++ b/src/specs/api.v2.yaml
@@ -1439,7 +1439,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
+                $ref: "#/components/schemas/HTTPSuccess"
         "400":
           description: Bad Request
           content:
@@ -1507,6 +1507,75 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/HTTPSuccess"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HTTPError"
+        "401":
+          description: The request lacks authentication credentials.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HTTPError"
+        "403":
+          description: Forbidden request for this user.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HTTPError"
+        "404":
+          description: Not found error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HTTPError"
+        "424":
+          description: Terms not accepted error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HTTPError"
+  "/experiments/{experimentId}/sampleFiles/{sampleFileId}/beginUpload":
+    post:
+      summary: Begins the multipart upload of a sample file
+      description: Begins the multipart upload of a sample file
+      operationId: beginUpload
+      x-eov-operation-id: sampleFile#beginUpload
+      x-eov-operation-handler: routes/sampleFile
+      parameters:
+        - name: experimentId
+          required: true
+          in: path
+          description: ID of the experiment.
+          schema:
+            type: string
+        - name: sampleFileId
+          in: path
+          description: Type of the file.
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/BeginSampleFileUpload"
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  signedUrls: 
+                    type: array
+                    items:
+                      type: string
+                  uploadId: 
+                    type: string
         "400":
           description: Bad Request
           content:
@@ -2481,6 +2550,8 @@ components:
       $ref: ./models/samples-bodies/CreateSampleFile.v2.yaml
     PatchSampleFile:
       $ref: ./models/samples-bodies/PatchSampleFile.v2.yaml
+    BeginSampleFileUpload: 
+      $ref: ./models/samples-bodies/BeginSampleFileUpload.v2.yaml
     UpdateSamplesOptions:
       $ref: ./models/samples-bodies/UpdateSamplesOptions.v2.yaml
     CellSets:

--- a/src/specs/models/samples-bodies/BeginSampleFileUpload.v2.yaml
+++ b/src/specs/models/samples-bodies/BeginSampleFileUpload.v2.yaml
@@ -1,0 +1,21 @@
+title: Begin sample file multipart upload
+description: 'Data to begin an s3 multipart upload'
+type: object
+properties:
+  size:
+    type: number
+  metadata:
+    description: Metadata to append to the s3 object on upload
+    type: object
+    properties:
+      cellrangerVersion:
+        type: string
+        oneOf:
+          - pattern: v2
+          - pattern: v3
+
+required:
+  - size
+  - metadata
+
+additionalProperties: false

--- a/src/specs/models/samples-bodies/CreateSampleFile.v2.yaml
+++ b/src/specs/models/samples-bodies/CreateSampleFile.v2.yaml
@@ -6,15 +6,6 @@ properties:
     type: string
   size:
     type: number
-  metadata:
-    description: Metadata to append to the s3 object on upload
-    type: object
-    properties:
-      cellrangerVersion:
-        type: string
-        oneOf:
-          - pattern: v2
-          - pattern: v3
  
 required:
   - sampleFileId

--- a/tests/api.v2/controllers/__snapshots__/sampleFileController.test.js.snap
+++ b/tests/api.v2/controllers/__snapshots__/sampleFileController.test.js.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`sampleFileController beginUpload works correctly if upload status of file is compressing 1`] = `
+Array [
+  Array [
+    "sampleFileId",
+  ],
+]
+`;
+
+exports[`sampleFileController beginUpload works correctly if upload status of file is uploading 1`] = `
+Array [
+  Array [
+    "sampleFileId",
+  ],
+]
+`;

--- a/tests/api.v2/controllers/sampleFileController.test.js
+++ b/tests/api.v2/controllers/sampleFileController.test.js
@@ -25,12 +25,12 @@ const mockRes = {
 };
 
 describe('sampleFileController', () => {
-  const mockSignedUrls = ['signedUrl'];
+  const mockUploadParams = { signedUrls: ['signedUrl1', 'signedUrl2'], fileId: 'mockfileId' };
 
   beforeEach(async () => {
     jest.clearAllMocks();
 
-    signedUrl.getFileUploadUrls.mockReturnValue(mockSignedUrls);
+    signedUrl.getFileUploadUrls.mockReturnValue(Promise.resolve(mockUploadParams));
   });
 
   it('createFile works correctly', async () => {
@@ -87,6 +87,26 @@ describe('sampleFileController', () => {
     ).rejects.toThrow();
 
     expect(mockRes.json).not.toHaveBeenCalled();
+  });
+
+  it('beginUpload works correctly', async () => {
+    const experimentId = 'experimentId';
+    const sampleFileId = 'sampleFileId';
+    const size = 10;
+    const metadata = {};
+
+    const mockReq = {
+      params: { experimentId, sampleFileId },
+      body: { metadata, size },
+    };
+
+    await sampleFileController.beginUpload(mockReq, mockRes);
+
+    expect(signedUrl.getFileUploadUrls).toHaveBeenCalledWith(
+      sampleFileId, metadata, size, bucketNames.SAMPLE_FILES,
+    );
+
+    expect(mockRes.json).toHaveBeenCalledWith(mockUploadParams);
   });
 
   it('patchFile works correctly', async () => {

--- a/tests/api.v2/controllers/sampleFileController.test.js
+++ b/tests/api.v2/controllers/sampleFileController.test.js
@@ -63,7 +63,7 @@ describe('sampleFileController', () => {
     expect(sampleInstance.setNewFile).toHaveBeenCalledWith('sampleId', 'sampleFileId', 'features10x');
 
     // Response is generated signed url
-    expect(mockRes.json).toHaveBeenCalledWith(mockSignedUrls);
+    expect(mockRes.json).toHaveBeenCalledWith(OK());
   });
 
   it('createFile errors out if the transaction failed', async () => {

--- a/tests/api.v2/routes/sampleFile.test.js
+++ b/tests/api.v2/routes/sampleFile.test.js
@@ -146,6 +146,39 @@ describe('tests for experiment route', () => {
       });
   });
 
+  it('beginUpload works', async (done) => {
+    sampleFileController.beginUpload.mockImplementationOnce((req, res) => {
+      res.json(OK());
+      return Promise.resolve();
+    });
+
+    const mockReq = {
+      params: { experimentId, sampleFileId },
+      body: { metadata, size },
+    };
+
+
+    const experimentId = 'mockExperimentId';
+    const sampleFileId = 'mockSampleFileId';
+
+    const patchFileBody = {
+      s3Path: 'features.tsv.gz',
+    };
+
+    request(app)
+      .patch(`/v2/experiments/${experimentId}/sampleFiles/${sampleFileId}`)
+      .send(patchFileBody)
+      .expect(400)
+      .end((err) => {
+        if (err) {
+          return done(err);
+        }
+        // there is no point testing for the values of the response body
+        // - if something is wrong, the schema validator will catch it
+        return done();
+      });
+  });
+
   it('Getting a sample file download url results in a successful response', async (done) => {
     sampleFileController.getS3DownloadUrl.mockImplementationOnce((req, res) => {
       res.json('mockSignedUrl');

--- a/tests/api.v2/routes/sampleFile.test.js
+++ b/tests/api.v2/routes/sampleFile.test.js
@@ -13,6 +13,7 @@ jest.mock('../../../src/api.v2/controllers/sampleFileController', () => ({
   patchFile: jest.fn(),
   getS3DownloadUrl: jest.fn(),
   completeMultipart: jest.fn(),
+  beginUpload: jest.fn(),
 }));
 
 jest.mock('../../../src/api.v2/middlewares/authMiddlewares');
@@ -152,22 +153,43 @@ describe('tests for experiment route', () => {
       return Promise.resolve();
     });
 
-    const mockReq = {
-      params: { experimentId, sampleFileId },
-      body: { metadata, size },
-    };
+    const experimentId = 'mockExperimentId';
+    const sampleFileId = 'mockSampleFileId';
+    const size = 10;
+    const metadata = {};
 
+    const body = { metadata, size };
+
+    request(app)
+      .post(`/v2/experiments/${experimentId}/sampleFiles/${sampleFileId}/beginUpload`)
+      .send(body)
+      .expect(200)
+      .end((err) => {
+        if (err) {
+          return done(err);
+        }
+        // there is no point testing for the values of the response body
+        // - if something is wrong, the schema validator will catch it
+        return done();
+      });
+  });
+
+  it('beginUpload fails if validation doesnt match', async (done) => {
+    sampleFileController.beginUpload.mockImplementationOnce((req, res) => {
+      res.json(OK());
+      return Promise.resolve();
+    });
 
     const experimentId = 'mockExperimentId';
     const sampleFileId = 'mockSampleFileId';
+    const size = 10;
 
-    const patchFileBody = {
-      s3Path: 'features.tsv.gz',
-    };
+    // Metadata is missing
+    const body = { size };
 
     request(app)
-      .patch(`/v2/experiments/${experimentId}/sampleFiles/${sampleFileId}`)
-      .send(patchFileBody)
+      .post(`/v2/experiments/${experimentId}/sampleFiles/${sampleFileId}/beginUpload`)
+      .send(body)
       .expect(400)
       .end((err) => {
         if (err) {


### PR DESCRIPTION
# Description
<!---  Write a brief description of what your code does and how it relates to the issue it is resolving or feature enhancement it is implementing. -->
The addition of multipart upload is not compatible with the pattern we had been following of making the create sample endpoint return the signed url necessary to upload the file itself.

This is because in its current state in `master`:
- To generate the signed urls to upload, we need to know how many parts the file is going to be split into --> **to create a file, we need to know its size**. As a consequence of this, when a file is not compressed, **we need to compress it before creating it** to store how its size will look like on creation.
- Apart from this, when a compression begins or fails, we need to update the file's upload status to display it to the user and to keep a record of it. To update a file's status, **we need to create a file before compressing it**.

Based on these points:
- we need to compress the file before creating it.
- we need to create the file before compressing it.

Clearly these 2 points don't work well together

### The fix 

There's one possible fix I discarded: mess with the upload status updates so that compression isn't shown or stored anywhere, I think this is likely to be a pretty complicated change to basically end up with less information and a degraded ux.

**The fix I went with** was to separate the sample files creation from the signed urls, now each of them have their own endpoint which are called by the ui, which works now in this order:
- create sample file.
- compress (with its upload status updates and all of that).
- get signed urls to multipart upload.

# Details
#### URL to issue
<!---
  Delete this comment and include the URL of the issue the pull request is related to.
  If no issue exists for this PR, replace this comment with N/A.

  Your pull request will not pass the required checks if this is not followed.
-->

#### Link to staging deployment URL (or set N/A)
N/A https://ui-martinfosco-ui26-api10.scp-staging.biomage.net/
<!---
  Delete this comment and include the URL of the staging environment for this pull request.
  Refer to https://github.com/hms-dbmi-cellenics/cellenics-utils#stage on how to stage a staging environment.
  If a staging environment for testing is not necessary for this PR, replace this comment with N/A 
  and explain why a staging environment is not required for this PR.

  Your pull request will not pass the required checks if this is not followed.
-->

#### Links to any PRs or resources related to this PR
https://github.com/hms-dbmi-cellenics/ui/pull/905
https://github.com/biomage-org/ui/pull/26
https://github.com/hms-dbmi-cellenics/api/pull/490
https://github.com/biomage-org/api/pull/10
<!---
  Delete this comment and include the URLs of any pull requests that are related to this PR.
  Place each PR on a new line.
-->

#### Integration test branch
master
<!---
  The branch of the integration test this PR will be run against

  If you DID NOT modify the integration tests for this PR, this can be left as `master`.

  If you DID modify the integration tests for this PR, add the name of the branch you created
  in hms-dbmi-cellenics/testing that will be used to test this branch.
-->

# Merge checklist
Your changes will be ready for merging after all of the steps below have been completed.
<!---
  The required checks will not pass until all the boxes below have been checked.
-->

### Code updates
Have best practices and ongoing refactors being observed in this PR
- [ ] Migrated any selector / reducer used to the new format.
- [ ] All new dependency licenses have been checked for compatibility

### Manual/unit testing
- [ ] Tested changes using InfraMock locally **or** no tests required for change, e.g. Kubernetes chart updates.
- [ ] Validated that current unit tests for code work as expected and are sufficient for code coverage **or** no unit tests required for change, e.g. documentation update.
- [ ] Unit tests written **or** no unit tests required for change, e.g. documentation update.

<!---
  Download the latest production data using `cellenics experiment pull`.
  To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
  To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/cellenics-utils
-->

### Integration testing
**You must check the box below** to run integration tests on the latest commit on your PR branch.
Integration tests have to pass before the PR can be merged. Without checking the box, your PR
**will not pass** the required status checks for merging.

- [x] Started end-to-end tests on the latest commit.

### Documentation updates
- [ ] Relevant Github READMEs updated **or** no GitHub README updates required.
- [ ] Relevant Wiki pages created/updated **or** no Wiki updates required.

### Optional
- [ ] Staging environment is unstaged before merging.
- [ ] Photo of a cute animal attached to this PR.
