### PR TITLE
always for for pods after scaling or if not avail

### DIFF
--- a/src/api.v2/helpers/worker/workSubmit/createWorkerK8s.js
+++ b/src/api.v2/helpers/worker/workSubmit/createWorkerK8s.js
@@ -1,6 +1,5 @@
 const k8s = require('@kubernetes/client-node');
 const config = require('../../../../config');
-const asyncTimer = require('../../../../utils/asyncTimer');
 const getLogger = require('../../../../utils/getLogger');
 
 const kc = new k8s.KubeConfig();
@@ -53,17 +52,8 @@ const getDeployment = async (name, namespace) => {
   return deployment;
 };
 
-const waitForPods = async (namespace, maxTries = 20, currentTry = 0) => {
-  logger.log('Waiting for pods...');
-  await asyncTimer(1000);
-  const pods = await getAvailablePods(namespace);
 
-  if (pods.length > 0 || currentTry >= maxTries) {
-    return;
-  }
-
-  await waitForPods(namespace, maxTries, currentTry + 1);
-};
+const waitForPods = require('./waitForPods');
 
 
 const scaleDeploymentReplicas = async (name, namespace, deployment, desiredReplicas = 1) => {
@@ -153,3 +143,4 @@ const createWorkerResources = async (service) => {
 };
 
 module.exports = createWorkerResources;
+module.exports.getAvailablePods = getAvailablePods;

--- a/src/api.v2/helpers/worker/workSubmit/createWorkerK8s.js
+++ b/src/api.v2/helpers/worker/workSubmit/createWorkerK8s.js
@@ -77,9 +77,6 @@ const scaleDeploymentReplicas = async (name, namespace, deployment, desiredRepli
 
   // replace
   await k8sApi.replaceNamespacedDeployment(name, namespace, deployment);
-
-  // wait until we have pods
-  await waitForPods(namespace);
 };
 
 
@@ -115,6 +112,12 @@ const createWorkerResources = async (service) => {
     }
   } catch (e) {
     logger.log('Could not scale replicas, ignoring...', e);
+  }
+
+  // Always wait for pods if none are available, even if scaling was not needed
+  if (pods.length < 1) {
+    await waitForPods(namespace);
+    pods = await getAvailablePods(namespace);
   }
 
   if (pods.length < 1) {

--- a/src/api.v2/helpers/worker/workSubmit/waitForPods.js
+++ b/src/api.v2/helpers/worker/workSubmit/waitForPods.js
@@ -1,0 +1,19 @@
+const asyncTimer = require('../../../../utils/asyncTimer');
+const getLogger = require('../../../../utils/getLogger');
+const { getAvailablePods } = require('./createWorkerK8s');
+
+const logger = getLogger();
+
+const waitForPods = async (namespace, maxTries = 20, currentTry = 0) => {
+  logger.log('Waiting for pods...');
+  await asyncTimer(1000);
+  const pods = await getAvailablePods(namespace);
+
+  if (pods.length > 0 || currentTry >= maxTries) {
+    return;
+  }
+
+  await waitForPods(namespace, maxTries, currentTry + 1);
+};
+
+module.exports = waitForPods;

--- a/tests/api.v2/helpers/worker/createWorkerK8s.test.js
+++ b/tests/api.v2/helpers/worker/createWorkerK8s.test.js
@@ -1,4 +1,3 @@
-
 const k8s = require('@kubernetes/client-node');
 const fake = require('../../../test-utils/constants');
 
@@ -59,7 +58,10 @@ k8s.KubeConfig.mockImplementation(() => {
 });
 
 const createWorkerK8s = require('../../../../src/api.v2/helpers/worker/workSubmit/createWorkerK8s');
+jest.mock('../../../../src/api.v2/helpers/worker/workSubmit/waitForPods', () => jest.fn(() => Promise.resolve()));
 
+// Mock waitForPods to resolve immediately for all tests
+jest.mock('../../../../src/api.v2/helpers/worker/workSubmit/waitForPods', () => jest.fn(() => Promise.resolve()));
 
 describe('tests for the pipeline-assign service', () => {
   afterEach(() => {


### PR DESCRIPTION
# Description
This pull request improves the reliability of worker pod creation by ensuring that the system always waits for pods to become available, regardless of whether scaling was necessary. The main change is to guarantee that the system waits for pods after attempting to scale, which helps prevent race conditions where no pods are available.

Pod availability handling:

* Ensured that after scaling (or if scaling is skipped), the system always waits for pods to become available by invoking `waitForPods` when no pods are present. This prevents errors when launching experiments due to missing worker pods.
* Removed redundant call to `waitForPods` from `scaleDeploymentReplicas`, centralizing pod availability checks in the worker resource creation logic.

# Details
#### URL to issue
N/A

#### Link to staging deployment URL (or set N/A)
N/A

#### Links to any PRs or resources related to this PR
<!---
  Delete this comment and include the URLs of any pull requests that are related to this PR.
  Place each PR on a new line.
-->

#### Integration test branch
master
<!---
  The branch of the integration test this PR will be run against

  If you DID NOT modify the integration tests for this PR, this can be left as `master`.

  If you DID modify the integration tests for this PR, add the name of the branch you created
  in hms-dbmi-cellenics/testing that will be used to test this branch.
-->

# Merge checklist
Your changes will be ready for merging after all of the steps below have been completed.
<!---
  The required checks will not pass until all the boxes below have been checked.
-->

### Code updates
Have best practices and ongoing refactors being observed in this PR
- [x] Migrated any selector / reducer used to the new format.
- [x] All new dependency licenses have been checked for compatibility

### Manual/unit testing
- [x] Tested changes using InfraMock locally **or** no tests required for change, e.g. Kubernetes chart updates.
- [x] Validated that current unit tests for code work as expected and are sufficient for code coverage **or** no unit tests required for change, e.g. documentation update.
- [x] Unit tests written **or** no unit tests required for change, e.g. documentation update.

<!---
  Download the latest production data using `cellenics experiment pull`.
  To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
  To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/cellenics-utils
-->

### Integration testing
**You must check the box below** to run integration tests on the latest commit on your PR branch.
Integration tests have to pass before the PR can be merged. Without checking the box, your PR
**will not pass** the required status checks for merging.

- [ ] Started end-to-end tests on the latest commit.

### Documentation updates
- [ ] Relevant Github READMEs updated **or** no GitHub README updates required.
- [ ] Relevant Wiki pages created/updated **or** no Wiki updates required.

### Optional
- [ ] Staging environment is unstaged before merging.
- [ ] Photo of a cute animal attached to this PR.