### PR TITLE
fix multiple pods assigned to same exp

### DIFF
--- a/src/api.v2/helpers/worker/workSubmit/waitForPods.js
+++ b/src/api.v2/helpers/worker/workSubmit/waitForPods.js
@@ -10,23 +10,35 @@ const getPods = async (namespace, statusSelector, labelSelector, kc) => {
   return pods.body.items;
 };
 
-const getAvailablePods = async (namespace, kc) => {
-  let pods = await getPods(namespace, 'status.phase=Running', '!experimentId,!run', kc);
+const getAvailablePods = async (namespace, kc, experimentId) => {
+  // Check if there are pods already assigned to this experiment
+  let pods = await getPods(namespace, 'status.phase=Running', `experimentId=${experimentId}`, kc);
+  if (pods.length > 0) {
+    return pods;
+  }
+  pods = await getPods(namespace, 'status.phase=Pending', `experimentId=${experimentId}`, kc);
+  if (pods.length > 0) {
+    return pods;
+  }
+
+  // Get unassigned pods
+  pods = await getPods(namespace, 'status.phase=Running', '!experimentId,!run', kc);
   if (pods.length < 1) {
     logger.log('no running pods available, trying to select pods still pending');
     pods = await getPods(namespace, 'status.phase=Pending', '!experimentId,!run', kc);
   }
+
   return pods;
 };
 
-const waitForPods = async (namespace, kc, maxWaitMs = 60000, pollIntervalMs = 1000) => {
-  let pods = await getAvailablePods(namespace, kc);
+const waitForPods = async (namespace, kc, experimentId, maxWaitMs = 60000, pollIntervalMs = 1000) => {
+  let pods = await getAvailablePods(namespace, kc, experimentId);
   const maxTries = Math.ceil(maxWaitMs / pollIntervalMs);
   for (let i = 0; pods.length < 1 && i < maxTries; i += 1) {
     logger.log('No available worker pods, waiting...');
     // eslint-disable-next-line no-await-in-loop
     await asyncTimer(pollIntervalMs);
-    pods = await getAvailablePods(namespace, kc);
+    pods = await getAvailablePods(namespace, kc, experimentId);
   }
   return pods;
 };


### PR DESCRIPTION
# Description
This pull request improves the pod assignment logic for experiments by ensuring that pods already assigned to a specific experiment are prioritized and returned immediately. The changes update how available pods are selected and how the system waits for pods to become available.

**Pod assignment and selection improvements:**

* Updated `waitForPods` and `getAvailablePods` to first look for pods already assigned to the given `experimentId` before searching for unassigned pods, ensuring experiments reuse their assigned pods if possible.
* Modified the pod selection logic in `createWorkerK8s.js` to check if a selected pod is already assigned to the experiment and, if so, return it immediately without patching, reducing unnecessary operations.

**Function signature and logging changes:**

* Changed the signatures of `waitForPods` and `getAvailablePods` to accept an `experimentId` parameter, and updated related calls accordingly. [[1]](diffhunk://#diff-a61af7ed80b604d2724aa8423c5f7d343e7e0ce4de90716c1c3b7a5ae40bc7f7L13-R41) [[2]](diffhunk://#diff-23f4fffd4be1e1771c3912378fd31160c16daf5135f7408ffa8a306ca705c686L101-R120)
* Improved logging messages for clarity, such as indicating when a pod is already assigned to an experiment and updating the description of candidate pods.

# Details
#### URL to issue
N/A

#### Link to staging deployment URL (or set N/A)
N/A

#### Links to any PRs or resources related to this PR
<!---
  Delete this comment and include the URLs of any pull requests that are related to this PR.
  Place each PR on a new line.
-->

#### Integration test branch
master
<!---
  The branch of the integration test this PR will be run against

  If you DID NOT modify the integration tests for this PR, this can be left as `master`.

  If you DID modify the integration tests for this PR, add the name of the branch you created
  in hms-dbmi-cellenics/testing that will be used to test this branch.
-->

# Merge checklist
Your changes will be ready for merging after all of the steps below have been completed.
<!---
  The required checks will not pass until all the boxes below have been checked.
-->

### Code updates
Have best practices and ongoing refactors being observed in this PR
- [ ] Migrated any selector / reducer used to the new format.
- [ ] All new dependency licenses have been checked for compatibility

### Manual/unit testing
- [ ] Tested changes using InfraMock locally **or** no tests required for change, e.g. Kubernetes chart updates.
- [ ] Validated that current unit tests for code work as expected and are sufficient for code coverage **or** no unit tests required for change, e.g. documentation update.
- [ ] Unit tests written **or** no unit tests required for change, e.g. documentation update.

<!---
  Download the latest production data using `cellenics experiment pull`.
  To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
  To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/cellenics-utils
-->

### Integration testing
**You must check the box below** to run integration tests on the latest commit on your PR branch.
Integration tests have to pass before the PR can be merged. Without checking the box, your PR
**will not pass** the required status checks for merging.

- [ ] Started end-to-end tests on the latest commit.

### Documentation updates
- [ ] Relevant Github READMEs updated **or** no GitHub README updates required.
- [ ] Relevant Wiki pages created/updated **or** no Wiki updates required.

### Optional
- [ ] Staging environment is unstaged before merging.
- [ ] Photo of a cute animal attached to this PR.