### PR TITLE
simplify createWorkerResources

### DIFF
--- a/src/api.v2/helpers/worker/workSubmit/createWorkerK8s.js
+++ b/src/api.v2/helpers/worker/workSubmit/createWorkerK8s.js
@@ -1,47 +1,12 @@
 const k8s = require('@kubernetes/client-node');
 const config = require('../../../../config');
 const getLogger = require('../../../../utils/getLogger');
-const waitForPods = require('./waitForPods');
+const waitForAvailablePods = require('./waitForAvailablePods');
 
 const kc = new k8s.KubeConfig();
 kc.loadFromDefault();
 
 const logger = getLogger();
-
-const getPods = async (namespace, statusSelector, labelSelector) => {
-  const k8sApi = kc.makeApiClient(k8s.CoreV1Api);
-
-  const pods = await k8sApi.listNamespacedPod(
-    namespace, null, null, null, statusSelector, labelSelector,
-  );
-  return pods.body.items;
-};
-
-const getAssignedPods = async (experimentId, namespace) => {
-  // check if there's already a running pod for this experiment
-  const assignedRunningPods = await getPods(namespace, 'status.phase=Running', `experimentId=${experimentId}`);
-  if (assignedRunningPods.length > 0) {
-    return assignedRunningPods;
-  }
-
-  // check if there's already a pending pod for this experiment
-  const assignedPendingPods = await getPods(namespace, 'status.phase=Pending', `experimentId=${experimentId}`);
-  if (assignedPendingPods.length > 0) {
-    return assignedPendingPods;
-  }
-
-  return [];
-};
-
-// getAvailablePods retrieves pods not assigned already to an activityID given a selector
-const getAvailablePods = async (namespace) => {
-  let pods = await getPods(namespace, 'status.phase=Running', '!experimentId,!run');
-  if (pods.length < 1) {
-    logger.log('no running pods available, trying to select pods still pending');
-    pods = await getPods(namespace, 'status.phase=Pending', '!experimentId,!run');
-  }
-  return pods;
-};
 
 const getDeployment = async (name, namespace) => {
   const k8sApi = kc.makeApiClient(k8s.AppsV1Api);
@@ -71,27 +36,13 @@ const createWorkerResources = async (service) => {
   const namespace = `worker-${sandboxId}`;
   const k8sApi = kc.makeApiClient(k8s.CoreV1Api);
 
-  // check if there's already an assigned pod to this experiment
-  const assignedPods = await getAssignedPods(experimentId, namespace);
-  if (assignedPods.length > 0) {
-    if (assignedPods.length > 1) {
-      logger.error(`Experiment ${experimentId} has two workers pods assigned.`);
-    }
-
-    const { metadata: { name, creationTimestamp }, status: { phase } } = assignedPods[0];
-    logger.log(`Experiment ${experimentId} already assigned a worker, skipping creation...`);
-    return { name, creationTimestamp, phase };
-  }
-
-
-  // scale pods if worker has zero replicas, and wait for pods to become available (retry up to timeout)
+  // scale pods if worker has less than desired replicas
   const minDesiredReplicas = 1;
-  let pods = await getAvailablePods(namespace);
 
   try {
     const deployment = await getDeployment('worker', namespace);
     const { replicas } = deployment.spec;
-    if (pods.length < 1 && replicas < minDesiredReplicas) {
+    if (replicas < minDesiredReplicas) {
       await scaleDeploymentReplicas('worker', namespace, deployment, minDesiredReplicas);
     }
   } catch (e) {
@@ -99,7 +50,7 @@ const createWorkerResources = async (service) => {
   }
 
   // Wait for pods to become available and return one
-  pods = await waitForPods(namespace, kc, experimentId);
+  const pods = await waitForAvailablePods(namespace, kc, experimentId);
 
   if (pods.length < 1) {
     throw new Error(`Experiment ${experimentId} cannot be launched as there are no available workers after waiting.`);

--- a/src/api.v2/helpers/worker/workSubmit/waitForAvailablePods.js
+++ b/src/api.v2/helpers/worker/workSubmit/waitForAvailablePods.js
@@ -31,7 +31,7 @@ const getAvailablePods = async (namespace, kc, experimentId) => {
   return pods;
 };
 
-const waitForPods = async (namespace, kc, experimentId, maxWaitMs = 60000, pollIntervalMs = 1000) => {
+const waitForAvailablePods = async (namespace, kc, experimentId, maxWaitMs = 60000, pollIntervalMs = 1000) => {
   let pods = await getAvailablePods(namespace, kc, experimentId);
   const maxTries = Math.ceil(maxWaitMs / pollIntervalMs);
   for (let i = 0; pods.length < 1 && i < maxTries; i += 1) {
@@ -43,4 +43,4 @@ const waitForPods = async (namespace, kc, experimentId, maxWaitMs = 60000, pollI
   return pods;
 };
 
-module.exports = waitForPods;
+module.exports = waitForAvailablePods;


### PR DESCRIPTION
# Description
This pull request refactors the worker pod assignment logic to simplify and consolidate pod selection and waiting functionality. The changes remove redundant pod assignment checks and unify the waiting logic under a single helper, improving clarity and maintainability. Tests have been updated to reflect these changes.


# Details
#### URL to issue
N/A

#### Link to staging deployment URL (or set N/A)
N/A

#### Links to any PRs or resources related to this PR
<!---
  Delete this comment and include the URLs of any pull requests that are related to this PR.
  Place each PR on a new line.
-->

#### Integration test branch
master
<!---
  The branch of the integration test this PR will be run against

  If you DID NOT modify the integration tests for this PR, this can be left as `master`.

  If you DID modify the integration tests for this PR, add the name of the branch you created
  in hms-dbmi-cellenics/testing that will be used to test this branch.
-->

# Merge checklist
Your changes will be ready for merging after all of the steps below have been completed.
<!---
  The required checks will not pass until all the boxes below have been checked.
-->

### Code updates
Have best practices and ongoing refactors being observed in this PR
- [ ] Migrated any selector / reducer used to the new format.
- [ ] All new dependency licenses have been checked for compatibility

### Manual/unit testing
- [ ] Tested changes using InfraMock locally **or** no tests required for change, e.g. Kubernetes chart updates.
- [ ] Validated that current unit tests for code work as expected and are sufficient for code coverage **or** no unit tests required for change, e.g. documentation update.
- [ ] Unit tests written **or** no unit tests required for change, e.g. documentation update.

<!---
  Download the latest production data using `cellenics experiment pull`.
  To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
  To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/cellenics-utils
-->

### Integration testing
**You must check the box below** to run integration tests on the latest commit on your PR branch.
Integration tests have to pass before the PR can be merged. Without checking the box, your PR
**will not pass** the required status checks for merging.

- [ ] Started end-to-end tests on the latest commit.

### Documentation updates
- [ ] Relevant Github READMEs updated **or** no GitHub README updates required.
- [ ] Relevant Wiki pages created/updated **or** no Wiki updates required.

### Optional
- [ ] Staging environment is unstaged before merging.
- [ ] Photo of a cute animal attached to this PR.