### PR TITLE
Fix: Support AWS Batch compute-N domain format in origin check

### DIFF
--- a/src/utils/isReqFrom.js
+++ b/src/utils/isReqFrom.js
@@ -3,8 +3,9 @@ const ipaddr = require('ipaddr.js');
 const config = require('../config');
 
 // eslint-disable-next-line no-useless-escape
-const INTERNAL_DOMAINS_REGEX = new RegExp(`((\.compute\.internal)|(\.svc\.local)|(${config.awsRegion}\.compute\.amazonaws\.com))$`);
-// awsRegion.compute.amazonaws.com => running in AWS Batch
+const INTERNAL_DOMAINS_REGEX = new RegExp(`((\.compute\.internal)|(\.svc\.local)|(${config.awsRegion}\.compute\.amazonaws\.com)|(compute-\\d+\.amazonaws\.com))$`);
+// awsRegion.compute.amazonaws.com => running in AWS Batch with region-specific domain
+// compute-N.amazonaws.com => running in AWS Batch (alternative format)
 // compute.internal & svc.local => running in cluster or fargate
 
 const isReqFromLocalhost = async (req) => {

--- a/tests/utils/isReqFrom.test.js
+++ b/tests/utils/isReqFrom.test.js
@@ -5,6 +5,7 @@ jest.mock('dns', () => ({
     reverse: jest.fn((ip) => {
       if (ip === '127.0.0.1') return [];
       if (ip === '54.220.234.41') return ['ec2-54-220-234-41.eu-west-1.compute.amazonaws.com'];
+      if (ip === '44.206.94.2') return ['ec2-44-206-94-2.compute-1.amazonaws.com'];
       return ['ip-192-168-905-123.region.compute.internal'];
     }),
   },
@@ -69,6 +70,18 @@ describe('Tests for isRequestFromCluster and isRequestFromLocalhost', () => {
       url: `/v1/experiments/${fake.EXPERIMENT_ID}/cellSets`,
       method: 'PATCH',
       ip: '54.220.234.41',
+    };
+
+    expect(await isReqFromCluster(req)).toEqual(true);
+  });
+
+  it('isReqFromCluster returns true for batch addr with compute-N domain', async () => {
+    const req = {
+      params: { experimentId: fake.EXPERIMENT_ID },
+      user: fake.USER,
+      url: `/v1/experiments/${fake.EXPERIMENT_ID}/cellSets`,
+      method: 'PATCH',
+      ip: '44.206.94.2',
     };
 
     expect(await isReqFromCluster(req)).toEqual(true);


### PR DESCRIPTION
# Description
Allow AWS Batch instances with compute-N.amazonaws.com domains to pass the origin check for expired JWT grace period on cellSets PATCH endpoint.

Previously only region-based domains (e.g., us-east-1.compute.amazonaws.com) were recognized as internal sources. This caused intermittent 401 failures for slow QC pipelines where batch jobs would have expired tokens by the time they attempted to patch cell sets.

Added regex pattern to match compute-\d+\.amazonaws\.com domains and added test case to verify the fix.


# Details
#### URL to issue
N/A

#### Link to staging deployment URL (or set N/A)
N/A

#### Links to any PRs or resources related to this PR
<!---
  Delete this comment and include the URLs of any pull requests that are related to this PR.
  Place each PR on a new line.
-->

#### Integration test branch
master
<!---
  The branch of the integration test this PR will be run against

  If you DID NOT modify the integration tests for this PR, this can be left as `master`.

  If you DID modify the integration tests for this PR, add the name of the branch you created
  in hms-dbmi-cellenics/testing that will be used to test this branch.
-->

# Merge checklist
Your changes will be ready for merging after all of the steps below have been completed.
<!---
  The required checks will not pass until all the boxes below have been checked.
-->

### Code updates
Have best practices and ongoing refactors being observed in this PR
- [x] Migrated any selector / reducer used to the new format.
- [x] All new dependency licenses have been checked for compatibility

### Manual/unit testing
- [x] Tested changes using InfraMock locally **or** no tests required for change, e.g. Kubernetes chart updates.
- [x] Validated that current unit tests for code work as expected and are sufficient for code coverage **or** no unit tests required for change, e.g. documentation update.
- [x] Unit tests written **or** no unit tests required for change, e.g. documentation update.

<!---
  Download the latest production data using `cellenics experiment pull`.
  To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
  To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/cellenics-utils
-->

### Integration testing
**You must check the box below** to run integration tests on the latest commit on your PR branch.
Integration tests have to pass before the PR can be merged. Without checking the box, your PR
**will not pass** the required status checks for merging.

- [ ] Started end-to-end tests on the latest commit.

### Documentation updates
- [ ] Relevant Github READMEs updated **or** no GitHub README updates required.
- [ ] Relevant Wiki pages created/updated **or** no Wiki updates required.

### Optional
- [ ] Staging environment is unstaged before merging.
- [ ] Photo of a cute animal attached to this PR.