### PR TITLE
invalidate worker cache on obj2s re-upload

### DIFF
--- a/src/api.v2/helpers/worker/generateEtag.js
+++ b/src/api.v2/helpers/worker/generateEtag.js
@@ -16,7 +16,20 @@ const generateETag = async (
   } = data;
 
   const backendStatus = await getExperimentBackendStatus(experimentId);
-  const { pipeline: { startDate: qcPipelineStartDate } } = backendStatus;
+  const {
+    pipeline: { startDate: qcStartDate },
+    obj2s: { startDate: obj2sStartDate },
+  } = backendStatus;
+
+  // obj2s experiments never run the QC pipeline, so `qcStartDate` stays null and
+  // always hashes to the same (epoch) date. That means re-uploading an obj2s
+  // object would produce an identical ETag and the worker would serve stale
+  // results from the previous upload (e.g. embeddings that no longer match the
+  // freshly overwritten cell sets, making clusters appear misaligned). Fall back
+  // to the obj2s pipeline start date so that re-running obj2s invalidates the
+  // cached worker results. gem2s/QC experiments keep using the QC start date, so
+  // their ETags are unchanged.
+  const qcPipelineStartDate = qcStartDate || obj2sStartDate;
 
   const { workerVersion } = config;
 

--- a/tests/api.v2/helpers/worker/generateEtag.test.js
+++ b/tests/api.v2/helpers/worker/generateEtag.test.js
@@ -1,0 +1,58 @@
+const generateETag = require('../../../../src/api.v2/helpers/worker/generateEtag');
+const getExperimentBackendStatus = require('../../../../src/api.v2/helpers/backendStatus/getExperimentBackendStatus');
+const getExtraDependencies = require('../../../../src/api.v2/helpers/worker/workSubmit/getExtraDependencies');
+
+jest.mock('../../../../src/api.v2/helpers/backendStatus/getExperimentBackendStatus');
+jest.mock('../../../../src/api.v2/helpers/worker/workSubmit/getExtraDependencies');
+
+const experimentId = 'experiment-id';
+
+const data = {
+  experimentId,
+  body: { name: 'GetEmbedding' },
+  requestProps: { broadcast: false, cacheUniquenessKey: null },
+};
+
+const backendStatus = ({ qcStartDate = null, obj2sStartDate = null }) => ({
+  pipeline: { startDate: qcStartDate },
+  obj2s: { startDate: obj2sStartDate },
+});
+
+describe('generateETag', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getExtraDependencies.mockResolvedValue([]);
+  });
+
+  it('produces a different ETag when the obj2s pipeline is re-run (QC never runs for obj2s)', async () => {
+    // obj2s experiments never run QC, so qc startDate stays null. The obj2s
+    // start date must feed the ETag so re-uploads invalidate stale worker results.
+    getExperimentBackendStatus.mockResolvedValueOnce(
+      backendStatus({ obj2sStartDate: '2024-01-01T00:00:00.000Z' }),
+    );
+    const firstETag = await generateETag(data);
+
+    getExperimentBackendStatus.mockResolvedValueOnce(
+      backendStatus({ obj2sStartDate: '2024-02-02T00:00:00.000Z' }),
+    );
+    const secondETag = await generateETag(data);
+
+    expect(firstETag).not.toEqual(secondETag);
+  });
+
+  it('is unaffected by the obj2s start date for gem2s/QC experiments', async () => {
+    // When QC has run, its start date drives the ETag and the obj2s date is ignored,
+    // keeping ETags stable for existing gem2s experiments.
+    getExperimentBackendStatus.mockResolvedValueOnce(
+      backendStatus({ qcStartDate: '2024-01-01T00:00:00.000Z' }),
+    );
+    const firstETag = await generateETag(data);
+
+    getExperimentBackendStatus.mockResolvedValueOnce(
+      backendStatus({ qcStartDate: '2024-01-01T00:00:00.000Z', obj2sStartDate: '2024-02-02T00:00:00.000Z' }),
+    );
+    const secondETag = await generateETag(data);
+
+    expect(firstETag).toEqual(secondETag);
+  });
+});


### PR DESCRIPTION
# Description
obj2s experiments never run QC, so the QC start date used in the worker ETag stayed null and re-uploads produced identical ETags, serving stale embeddings against freshly written cell sets. Fall back to the obj2s pipeline start date when the QC date is absent.

# Details
#### URL to issue
N/A

#### Link to staging deployment URL (or set N/A)
N/A

#### Links to any PRs or resources related to this PR
<!---
  Delete this comment and include the URLs of any pull requests that are related to this PR.
  Place each PR on a new line.
-->

#### Integration test branch
master
<!---
  The branch of the integration test this PR will be run against

  If you DID NOT modify the integration tests for this PR, this can be left as `master`.

  If you DID modify the integration tests for this PR, add the name of the branch you created
  in hms-dbmi-cellenics/testing that will be used to test this branch.
-->

# Merge checklist
Your changes will be ready for merging after all of the steps below have been completed.
<!---
  The required checks will not pass until all the boxes below have been checked.
-->

### Code updates
Have best practices and ongoing refactors being observed in this PR
- [x] Migrated any selector / reducer used to the new format.
- [x] All new dependency licenses have been checked for compatibility

### Manual/unit testing
- [x] Tested changes using InfraMock locally **or** no tests required for change, e.g. Kubernetes chart updates.
- [x] Validated that current unit tests for code work as expected and are sufficient for code coverage **or** no unit tests required for change, e.g. documentation update.
- [x] Unit tests written **or** no unit tests required for change, e.g. documentation update.

<!---
  Download the latest production data using `cellenics experiment pull`.
  To set up easy local testing with inframock, follow the instructions here: https://github.com/hms-dbmi-cellenics/inframock
  To deploy to the staging environment, follow the instructions here: https://github.com/hms-dbmi-cellenics/cellenics-utils
-->

### Integration testing
**You must check the box below** to run integration tests on the latest commit on your PR branch.
Integration tests have to pass before the PR can be merged. Without checking the box, your PR
**will not pass** the required status checks for merging.

- [ ] Started end-to-end tests on the latest commit.

### Documentation updates
- [ ] Relevant Github READMEs updated **or** no GitHub README updates required.
- [ ] Relevant Wiki pages created/updated **or** no Wiki updates required.

### Optional
- [ ] Staging environment is unstaged before merging.
- [ ] Photo of a cute animal attached to this PR.